### PR TITLE
chore: lean CI — drop Python 3.12, monthly dep bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
+      interval: monthly
+    open-pull-requests-limit: 3
     labels:
       - dependencies
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.13"]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Cuts CI costs at the early stage where every minute counts.

- **CI matrix**: 3.11 + 3.13 only (drops 3.12 — covers min and max, no new signal from middle version)
- **Dependabot pip**: weekly → monthly, max PRs 5 → 3
- **Branch protection**: updated to match new matrix

## When to reverse this

Add 3.12 back if a user reports a 3.12-specific bug, or when approaching a stable v1.0 release where full matrix coverage matters for credibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)