### PR TITLE
fix: block SSRF in unsubscribe engine via URL validation

### DIFF
--- a/mailtrim/core/unsubscribe.py
+++ b/mailtrim/core/unsubscribe.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import ipaddress
 import re
+import socket
+import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
@@ -10,6 +13,67 @@ import httpx
 
 from mailtrim.core.gmail_client import GmailClient, Message
 from mailtrim.core.storage import UnsubscribeRecord, get_session
+
+# ── URL safety validation ─────────────────────────────────────────────────────
+
+# Private, loopback, and link-local ranges that must never be fetched.
+# Link-local (169.254/16) covers AWS/GCP/Azure instance metadata endpoints.
+_BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local / cloud metadata
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+
+def _is_safe_url(url: str) -> tuple[bool, str]:
+    """
+    Validate that a URL is safe to fetch before making any outbound request.
+
+    Returns (safe: bool, reason: str). Blocks:
+    - Non-http(s) schemes (file://, ftp://, etc.)
+    - Private / loopback / link-local IP ranges (SSRF prevention)
+    - Hostnames that fail DNS resolution
+
+    This guards against SSRF attacks where a malicious sender plants a
+    crafted List-Unsubscribe header pointing at internal infrastructure
+    (e.g. http://169.254.169.254/latest/meta-data/).
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except Exception:
+        return False, "malformed URL"
+
+    if parsed.scheme not in ("http", "https"):
+        return False, f"scheme '{parsed.scheme}' not allowed — only http/https"
+
+    host = parsed.hostname
+    if not host:
+        return False, "no hostname"
+
+    # Resolve all addresses the hostname maps to and check every one.
+    # We check all, not just the first, to prevent DNS rebinding attacks.
+    try:
+        addr_infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False, f"hostname '{host}' did not resolve"
+
+    for info in addr_infos:
+        raw_addr = info[4][0]
+        try:
+            ip = ipaddress.ip_address(raw_addr)
+        except ValueError:
+            return False, f"could not parse resolved address '{raw_addr}'"
+        for network in _BLOCKED_NETWORKS:
+            if ip in network:
+                return False, f"'{host}' resolves to private/reserved address {ip}"
+
+    return True, ""
 
 
 @dataclass
@@ -96,12 +160,15 @@ class UnsubscribeEngine:
     # ── Stage 1a: RFC 8058 one-click POST ────────────────────────────────────
 
     def _one_click_post(self, url: str, sender: str) -> UnsubscribeResult:
+        safe, reason = _is_safe_url(url)
+        if not safe:
+            return UnsubscribeResult(sender, "header_url", False, f"Blocked unsafe URL: {reason}")
         try:
             resp = httpx.post(
                 url,
                 data={"List-Unsubscribe": "One-Click"},
                 timeout=10,
-                follow_redirects=True,
+                follow_redirects=False,  # never follow redirects to avoid redirect-based SSRF
             )
             if resp.status_code < 400:
                 return UnsubscribeResult(
@@ -138,8 +205,11 @@ class UnsubscribeEngine:
     # ── Stage 1c: URL GET ────────────────────────────────────────────────────
 
     def _url_unsubscribe(self, url: str, sender: str) -> UnsubscribeResult:
+        safe, reason = _is_safe_url(url)
+        if not safe:
+            return UnsubscribeResult(sender, "header_url", False, f"Blocked unsafe URL: {reason}")
         try:
-            resp = httpx.get(url, timeout=10, follow_redirects=True)
+            resp = httpx.get(url, timeout=10, follow_redirects=False)
             if resp.status_code < 400:
                 return UnsubscribeResult(
                     sender,
@@ -174,6 +244,10 @@ class UnsubscribeEngine:
             return UnsubscribeResult(
                 sender, "headless", False, "No unsubscribe link found in email body."
             )
+
+        safe, reason = _is_safe_url(unsub_url)
+        if not safe:
+            return UnsubscribeResult(sender, "headless", False, f"Blocked unsafe URL: {reason}")
 
         try:
             with sync_playwright() as p:

--- a/tests/test_ssrf_protection.py
+++ b/tests/test_ssrf_protection.py
@@ -1,0 +1,148 @@
+"""Tests for SSRF protection in the unsubscribe URL validator."""
+
+import pytest
+
+
+def test_safe_public_https_url(monkeypatch):
+    import socket
+
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    # Stub DNS: resolve to a known public IP (93.184.216.34 = example.com)
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda host, port, *a, **kw: [(None, None, None, None, ("93.184.216.34", 0))],
+    )
+    safe, reason = _is_safe_url("https://unsubscribe.example.com/opt-out?token=abc")
+    assert safe is True
+    assert reason == ""
+
+
+def test_safe_public_http_url(monkeypatch):
+    import socket
+
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda host, port, *a, **kw: [(None, None, None, None, ("93.184.216.34", 0))],
+    )
+    safe, reason = _is_safe_url("http://unsubscribe.example.com/remove")
+    assert safe is True
+
+
+def test_blocks_aws_metadata_endpoint():
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    safe, reason = _is_safe_url("http://169.254.169.254/latest/meta-data/")
+    assert safe is False
+    assert "private" in reason or "reserved" in reason
+
+
+def test_blocks_loopback():
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    safe, reason = _is_safe_url("http://127.0.0.1/admin")
+    assert safe is False
+
+
+def test_blocks_loopback_localhost():
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    safe, reason = _is_safe_url("http://localhost/admin")
+    assert safe is False
+
+
+def test_blocks_rfc1918_10_range():
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    safe, reason = _is_safe_url("http://10.0.0.1/internal")
+    assert safe is False
+
+
+def test_blocks_rfc1918_192168_range():
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    safe, reason = _is_safe_url("http://192.168.1.100/service")
+    assert safe is False
+
+
+def test_blocks_rfc1918_172_range():
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    safe, reason = _is_safe_url("http://172.16.0.1/internal")
+    assert safe is False
+
+
+def test_blocks_non_http_scheme_file():
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    safe, reason = _is_safe_url("file:///etc/passwd")
+    assert safe is False
+    assert "scheme" in reason
+
+
+def test_blocks_non_http_scheme_ftp():
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    safe, reason = _is_safe_url("ftp://example.com/file")
+    assert safe is False
+    assert "scheme" in reason
+
+
+def test_blocks_missing_hostname():
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    safe, reason = _is_safe_url("http:///path/only")
+    assert safe is False
+
+
+def test_blocks_unresolvable_hostname():
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    safe, reason = _is_safe_url("https://this-domain-does-not-exist.invalid/unsub")
+    assert safe is False
+    assert "resolve" in reason
+
+
+def test_blocks_malformed_url():
+    from mailtrim.core.unsubscribe import _is_safe_url
+
+    safe, reason = _is_safe_url("not a url at all !!!")
+    assert safe is False
+
+
+def test_one_click_post_blocked_for_private_url(monkeypatch):
+    """_one_click_post must not make any HTTP call when URL is unsafe."""
+    import httpx
+
+    from mailtrim.core.unsubscribe import UnsubscribeEngine
+
+    calls = []
+    monkeypatch.setattr(httpx, "post", lambda *a, **kw: calls.append((a, kw)))
+
+    engine = UnsubscribeEngine.__new__(UnsubscribeEngine)
+    result = engine._one_click_post("http://169.254.169.254/latest/", "bad@evil.com")
+
+    assert result.success is False
+    assert "Blocked" in result.message
+    assert calls == []  # httpx.post must never have been called
+
+
+def test_url_unsubscribe_blocked_for_loopback(monkeypatch):
+    """_url_unsubscribe must not make any HTTP call when URL is unsafe."""
+    import httpx
+
+    from mailtrim.core.unsubscribe import UnsubscribeEngine
+
+    calls = []
+    monkeypatch.setattr(httpx, "get", lambda *a, **kw: calls.append((a, kw)))
+
+    engine = UnsubscribeEngine.__new__(UnsubscribeEngine)
+    result = engine._url_unsubscribe("http://127.0.0.1:8080/admin", "bad@evil.com")
+
+    assert result.success is False
+    assert "Blocked" in result.message
+    assert calls == []


### PR DESCRIPTION
## Summary

Fixes #9 — SSRF via attacker-controlled `List-Unsubscribe` URLs.

URLs from email headers were passed directly to `httpx` with no validation, allowing a malicious sender to trigger outbound requests to internal infrastructure (AWS/GCP/Azure metadata endpoints, RFC1918 hosts, localhost admin panels).

**What changed:**
- New `_is_safe_url()` validator runs before every outbound fetch
- Blocks RFC1918 (10/8, 172.16/12, 192.168/16), loopback (127/8), link-local (169.254/16 — covers cloud metadata endpoints), IPv6 private ranges
- Resolves **all** addresses for the hostname (not just the first) to prevent DNS rebinding
- Blocks unresolvable hostnames
- `follow_redirects=False` on all `httpx` calls to prevent redirect-based SSRF
- Protection applied at all three fetch points: `_one_click_post`, `_url_unsubscribe`, `_headless_unsubscribe`

**Severity context:** Medium for a local CLI tool (attacker cannot exfiltrate the response body directly), but real risk on corporate networks and cloud VMs where side-effect-based endpoints exist.

## Test plan

- [ ] CI passes (130 tests + 15 new SSRF tests)
- [ ] `http://169.254.169.254/...` → blocked
- [ ] `http://127.0.0.1/...` → blocked
- [ ] `http://localhost/...` → blocked
- [ ] `http://10.0.0.1/...` → blocked
- [ ] `file:///etc/passwd` → blocked
- [ ] Public `https://` URL with valid DNS → passes
- [ ] `httpx` is never called for blocked URLs (verified by monkeypatch in tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)