### PR TITLE
fix: pin ruff version and resolve pre-commit/CI format mismatch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Ruff: lint + format (replaces flake8, isort, black)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.0
+    rev: v0.15.9  # keep in sync with ruff version in pyproject.toml [dev]
     hooks:
       - id: ruff
         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=5.0.0",
-    "ruff>=0.4.0",
+    "ruff>=0.15.9",
     "bandit>=1.7.0",
     "pre-commit>=3.7.0",
 ]


### PR DESCRIPTION
## Summary

Fixes the CI format failure that appeared after PR #13 merged, and closes the root cause permanently.

**Root cause:** `.pre-commit-config.yaml` pinned ruff at `v0.4.0` while the venv (and CI) had `v0.15.9`. The two versions format assert messages differently, causing each to reformat what the other had just written — a loop that made CI always fail.

**Changes:**
- Pin ruff to `v0.15.9` in both `.pre-commit-config.yaml` and `pyproject.toml [dev]` so local and CI always use the same formatter
- Reformat `tests/test_purge.py` to match ruff v0.15.9 output
- Fix ruff auto-fixes applied to test files (unused imports, import ordering)

## Test plan

- [ ] CI passes (format check, lint, tests)
- [ ] `pre-commit run --all-files` passes locally with no modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)