### PR TITLE
feat: provider-agnostic email, local AI backends, and DX improvements (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,41 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [0.2.1] — 2026-04-11
+
 ### Added
-- `--scope anywhere` flag on `stats`, `purge`, and `sync` — scans all mail
-  (`in:anywhere -in:trash -in:spam`), not just inbox. Surfaces hidden bloat
-  in archived, sent, and all-mail folders. Most storage waste is not in inbox.
+- `mailtrim doctor` — health check command: verifies auth token, Gmail connection,
+  Trash access, data directory, undo storage, config, and optional local AI endpoint.
+  Prints ✓/⚠/✗ per check with actionable fix hints. Exits non-zero when required checks fail.
+- `mailtrim quickstart` — guided first-run command: checks auth, scans 500 messages,
+  explains what was found, surfaces the single safest first cleanup action.
+- `--verbose` / `--simple` flags on `stats`:
+  - `--verbose` shows ACCOUNT SUMMARY, KEY INSIGHTS, domain patterns, full TOP SENDERS table
+  - `--simple` shows plain-language recommendations without scores or tables
+- `mailtrim stats --max-scan` default raised from 300 → 1000 for better coverage
+- Human-readable error messages: 401/expired token, network timeouts, permission errors,
+  rate limits, and database corruption all show plain-language guidance instead of raw tracebacks
+- Local-only usage metrics (`~/.mailtrim/usage.json`): command runs, emails trashed,
+  undo count, first run date — never uploaded, used only for local product insight
+- `DEMO.md` — 60-second demo script for recording an asciinema/vhs walkthrough
+
+### Changed
+- `--permanent` flag on `purge` is now hidden from `--help` and requires a second
+  `--i-understand-permanent` flag; confirmation phrase changed to `DELETE FOREVER`
+- `--imap-password` CLI flag removed from `stats` and `purge` — now read from
+  `MAILTRIM_IMAP_PASSWORD` env var or interactive hidden prompt (no shell history leak)
+- `purge` docstring: "delete" → "move to Trash (recoverable)"
+- `stats` docstring: "delete" → "move to Trash"
+- `_action_explanation()` now says "Moves … to Trash (recoverable)" instead of "Deletes"
+- `digest`, `avoid`, `follow-up`, and `stats --ai` marked `[EXPERIMENTAL]` in help text
+- `undo` completion message: "Restored X emails" with progress spinner
+- `_print_cleanup_complete`: undo hint is now bold and prominent
+
+### Fixed
+- `test_confidence_safety_label_medium` and `_low` tests updated to match current
+  `confidence_safety_label()` return values ("Needs review", "Sensitive / personal")
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # mailtrim
 
-**Delete years of Gmail clutter in minutes. Free, open-source. Core features need no API key.**
+**mailtrim helps you clean your inbox safely in seconds — everything goes to Trash first, undo anytime, nothing leaves your machine.**
+
+Free, open-source. Core features need no API key.
 
 [![PyPI](https://img.shields.io/pypi/v/mailtrim.svg)](https://pypi.org/project/mailtrim/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://python.org)
@@ -58,6 +60,56 @@ The paid tools charge $7–$40/month, process your email on their servers, and s
 | AI classification + NL cleanup | `triage`, `bulk`, `avoid`, `digest`, `rules --add` | Requires [Anthropic API key](https://console.anthropic.com) · ~$0.01–0.05 per run |
 
 The core cleanup workflow — scan, rank, delete, undo — costs nothing and requires no AI key. AI features are optional and pay-per-use; there is no subscription.
+
+---
+
+## 60-Second Quick Start
+
+Already have credentials.json from Google? This is all you need:
+
+```bash
+pip install mailtrim
+mailtrim auth        # opens browser once
+mailtrim quickstart  # guided first cleanup
+```
+
+Not set up yet? See the full setup below — it takes about 15 minutes once.
+
+---
+
+## Safe by Default
+
+- **Everything goes to Trash first** — nothing is permanently deleted unless you explicitly use `--permanent` (hidden flag, requires a second confirmation flag)
+- **30-day undo window** — run `mailtrim undo` anytime to reverse any cleanup
+- **All data stays on your machine** — `~/.mailtrim/` only, no telemetry, no cloud sync
+- **Dry-run first** — most commands show you what they'd do before asking you to confirm
+
+```bash
+mailtrim purge --domain linkedin.com   # shows what would be deleted, asks to confirm
+mailtrim undo                          # shows recent operations, pick one to reverse
+mailtrim doctor                        # checks auth, storage, and connection health
+```
+
+---
+
+## Common Fixes
+
+If something isn't working, run:
+
+```bash
+mailtrim doctor
+```
+
+This checks auth, Gmail connection, storage, and optional AI — and tells you exactly what to fix.
+
+| Symptom | Fix |
+|---------|-----|
+| "Gmail connection expired" | `mailtrim auth` |
+| "Token file not found" | `mailtrim auth` |
+| "Cannot write to ~/.mailtrim/" | `chmod 700 ~/.mailtrim` |
+| "Rate limit hit" | Wait 60 seconds, retry with `--max-scan 300` |
+| Scan feels slow | Use `--max-scan 500` (default is 1000) |
+| Not seeing enough senders | Try `mailtrim stats --scope anywhere` |
 
 ---
 
@@ -175,6 +227,19 @@ Free forever. → https://github.com/sadhgurutech/mailtrim
 ---
 
 ## All Commands
+
+### `quickstart` — Guided first cleanup *(no AI needed)*
+
+```bash
+mailtrim quickstart   # checks auth, scans inbox, shows your first safe action
+```
+
+### `doctor` — Health check
+
+```bash
+mailtrim doctor        # checks auth, Gmail, storage, config
+mailtrim doctor --ai   # also checks local AI endpoint
+```
 
 ### `stats` — Quick inbox overview *(no AI needed)*
 
@@ -311,7 +376,7 @@ MAILTRIM_UNDO_WINDOW_DAYS=30
 ## Testing (no credentials required)
 
 ```bash
-# Run all 115 tests — zero API calls, zero credentials needed
+# Run all tests — zero API calls, zero credentials needed
 python -m pytest tests/ -v
 
 # With coverage
@@ -342,8 +407,11 @@ mailtrim/
 │   ├── bulk_engine.py     # NL → dry-run preview → execute → 30-day undo
 │   ├── avoidance.py       # "Emails you avoid" detector + per-email AI insight
 │   ├── unsubscribe.py     # RFC 8058 one-click + mailto + Playwright headless
-│   └── sender_stats.py    # Sender aggregation for stats/purge commands
-└── cli/main.py            # Typer + Rich CLI — 11 commands
+│   ├── sender_stats.py    # Sender aggregation for stats/purge commands
+│   ├── diagnostics.py     # doctor command checks (auth, storage, connection)
+│   ├── errors.py          # Human-readable error translation layer
+│   └── usage_stats.py     # Local-only run metrics (never uploaded)
+└── cli/main.py            # Typer + Rich CLI — 13 commands
 ```
 
 ---

--- a/mailtrim/__init__.py
+++ b/mailtrim/__init__.py
@@ -1,3 +1,3 @@
 """mailtrim: Privacy-first, AI-powered Gmail inbox management."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.1"

--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -36,6 +36,34 @@ def _get_client():
     return GmailClient(creds)
 
 
+def _get_provider(
+    provider: str = "gmail",
+    imap_server: str = "",
+    imap_user: str = "",
+    imap_password: str = "",
+    imap_port: int = 993,
+):
+    """Construct the EmailProvider selected by --provider."""
+    from mailtrim.core.providers.factory import get_provider
+
+    return get_provider(
+        provider=provider,
+        imap_server=imap_server,
+        imap_user=imap_user,
+        imap_password=imap_password,
+        imap_port=imap_port,
+    )
+
+
+def _get_ai_client_opt(backend: str, url: str, model: str):
+    """Return an AIClient override, or None to use the llm.py default."""
+    if backend == "llama" and not url:
+        return None  # default client already configured in llm.py
+    from mailtrim.core.ai.client import get_ai_client
+
+    return get_ai_client(backend=backend, url=url, model=model)
+
+
 def _get_ai():
     from mailtrim.core.mock_ai import get_ai_engine
 
@@ -139,6 +167,23 @@ def stats(
         "--ai",
         help="Enrich sender insights with local AI (requires llama.cpp at localhost:8080).",
     ),
+    provider: str = typer.Option(
+        "gmail",
+        "--provider",
+        help="Email provider: gmail (default) or imap.",
+    ),
+    imap_server: str = typer.Option("", "--imap-server", help="IMAP server hostname."),
+    imap_user: str = typer.Option("", "--imap-user", help="IMAP login username."),
+    imap_password: str = typer.Option(
+        "", "--imap-password", help="IMAP app password.", hide_input=True
+    ),
+    ai_backend: str = typer.Option(
+        "llama",
+        "--ai-backend",
+        help="Local AI backend: llama (llama.cpp, default) or ollama.",
+    ),
+    ai_url: str = typer.Option("", "--ai-url", help="Override local AI server URL."),
+    ai_model: str = typer.Option("phi3", "--ai-model", help="Model name (Ollama only)."),
 ):
     """
     Inbox decision engine — reclaimable space, confidence-scored recommendations, top senders.
@@ -182,7 +227,12 @@ def stats(
         scope_label = "inbox"
 
     scan_start = _time.time()
-    client = _get_client()
+    client = _get_provider(
+        provider=provider,
+        imap_server=imap_server,
+        imap_user=imap_user,
+        imap_password=imap_password,
+    )
 
     with Progress(SpinnerColumn(), TextColumn("{task.description}"), console=console) as p:
         t = p.add_task(f"Scanning {scope_label}…", total=None)
@@ -491,26 +541,28 @@ def stats(
     ai_insights: dict[str, dict] = {}
     if use_ai and recommendations:
         from mailtrim.core.llm import (
-            CATEGORY_ICON,
             analyze_batch,
             confidence_delta,
             should_analyze,
         )
 
         eligible = [
-            rec for rec in recommendations
+            rec
+            for rec in recommendations
             if should_analyze(rec.confidence, rec.sender.count, rec.sender.sender_email)
         ]
         if eligible:
             with console.status("[dim][AI] Analyzing senders via local model…[/dim]"):
                 texts = ["\n".join(rec.sender.sample_subjects) for rec in eligible]
                 keys = [rec.sender.sender_email for rec in eligible]
-                results = analyze_batch(texts, cache_keys=keys)
+                _ai_client_override = _get_ai_client_opt(ai_backend, ai_url, ai_model)
+                results = analyze_batch(texts, cache_keys=keys, ai_client=_ai_client_override)
             for rec, result in zip(eligible, results):
                 ai_insights[rec.sender.sender_email] = result
 
         if ai_insights:
             from mailtrim.core.llm import apply_impact_nudge
+
             apply_impact_nudge(groups, ai_insights)
 
     if recommendations:
@@ -706,14 +758,20 @@ def triage(
     classified = None
     try:
         import anthropic
+
         from mailtrim.core.ai_engine import AIEngine
 
         ai = AIEngine()  # raises ValueError if ANTHROPIC_API_KEY is unset
         _print_ai_data_notice(f"{len(messages)} email subjects + snippets (≤300 chars each)")
         with console.status(f"Classifying {len(messages)} messages with Anthropic AI..."):
             classified = ai.classify_emails(messages)
-    except (ValueError, anthropic.AuthenticationError, anthropic.RateLimitError,
-            anthropic.APIStatusError, anthropic.APIConnectionError) as exc:
+    except (
+        ValueError,
+        anthropic.AuthenticationError,
+        anthropic.RateLimitError,
+        anthropic.APIStatusError,
+        anthropic.APIConnectionError,
+    ) as exc:
         # ValueError              → ANTHROPIC_API_KEY not set
         # AuthenticationError     → key present but invalid
         # RateLimitError          → quota exceeded, fall back gracefully
@@ -1132,6 +1190,7 @@ def unsubscribe(
     messages: list = []
     if sender:
         from mailtrim.core.validation import validate_sender_email
+
         sender = validate_sender_email(sender)
         with console.status(f"Finding emails from {sender}..."):
             ids = client.list_message_ids(query=f"from:{sender}", max_results=1)
@@ -1429,6 +1488,17 @@ def purge(
         "--ai",
         help="Adjust confidence scores with local AI signal (requires llama.cpp at localhost:8080).",
     ),
+    provider: str = typer.Option("gmail", "--provider", help="Email provider: gmail or imap."),
+    imap_server: str = typer.Option("", "--imap-server", help="IMAP server hostname."),
+    imap_user: str = typer.Option("", "--imap-user", help="IMAP login username."),
+    imap_password: str = typer.Option(
+        "", "--imap-password", help="IMAP app password.", hide_input=True
+    ),
+    ai_backend: str = typer.Option(
+        "llama", "--ai-backend", help="Local AI backend: llama or ollama."
+    ),
+    ai_url: str = typer.Option("", "--ai-url", help="Override local AI server URL."),
+    ai_model: str = typer.Option("phi3", "--ai-model", help="Model name (Ollama only)."),
 ):
     """
     Show top email offenders and bulk-delete the ones you choose.
@@ -1453,7 +1523,12 @@ def purge(
     from mailtrim.core.unsubscribe import UnsubscribeEngine
     from mailtrim.core.validation import validate_domain, validate_older_than
 
-    client = _get_client()
+    client = _get_provider(
+        provider=provider,
+        imap_server=imap_server,
+        imap_user=imap_user,
+        imap_password=imap_password,
+    )
     account_email = _get_account_email(client)
 
     # Validate user-supplied values before embedding them in Gmail queries.
@@ -1605,17 +1680,15 @@ def purge(
         # Gmail's from: query is a suffix match, so mail.domain.com is included.
         unique_domains = sorted({g.domain for g in groups})
         if len(unique_domains) > 1:
-            console.print(
-                f"[dim]  Includes subdomains: {', '.join(unique_domains)}[/dim]"
-            )
+            console.print(f"[dim]  Includes subdomains: {', '.join(unique_domains)}[/dim]")
         for g in sorted(groups, key=lambda x: x.count, reverse=True)[:10]:
             size_str = (
-                f"{g.total_size_mb} MB" if g.total_size_mb >= 0.1
+                f"{g.total_size_mb} MB"
+                if g.total_size_mb >= 0.1
                 else f"{g.total_size_bytes // 1024} KB"
             )
             console.print(
-                f"  [dim]{g.sender_email}[/dim]  "
-                f"[red]{g.count}[/red] emails · {size_str}"
+                f"  [dim]{g.sender_email}[/dim]  [red]{g.count}[/red] emails · {size_str}"
             )
         if len(groups) > 10:
             console.print(f"  [dim]… and {len(groups) - 10} more sender(s)[/dim]")
@@ -1661,27 +1734,27 @@ def purge(
     purge_ai_insights: dict[str, dict] = {}
     if use_ai:
         from mailtrim.core.llm import (
-            CATEGORY_ICON,
             analyze_batch,
             confidence_delta,
             should_analyze,
         )
 
         eligible_groups = [
-            g for g in groups
+            g
+            for g in groups
             if should_analyze(compute_confidence_score(g), g.count, g.sender_email)
         ]
         if eligible_groups:
             with console.status("[dim][AI] Analyzing senders via local model…[/dim]"):
                 texts = ["\n".join(g.sample_subjects) for g in eligible_groups]
                 keys = [g.sender_email for g in eligible_groups]
-                ai_results = analyze_batch(texts, cache_keys=keys)
-            purge_ai_insights = {
-                g.sender_email: r for g, r in zip(eligible_groups, ai_results)
-            }
+                _purge_ai_client = _get_ai_client_opt(ai_backend, ai_url, ai_model)
+                ai_results = analyze_batch(texts, cache_keys=keys, ai_client=_purge_ai_client)
+            purge_ai_insights = {g.sender_email: r for g, r in zip(eligible_groups, ai_results)}
 
         if purge_ai_insights:
             from mailtrim.core.llm import apply_impact_nudge
+
             apply_impact_nudge(groups, purge_ai_insights)
 
     console.print()

--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -42,6 +42,7 @@ def _get_provider(
     imap_user: str = "",
     imap_password: str = "",
     imap_port: int = 993,
+    imap_folder: str = "INBOX",
 ):
     """Construct the EmailProvider selected by --provider."""
     from mailtrim.core.providers.factory import get_provider
@@ -52,6 +53,7 @@ def _get_provider(
         imap_user=imap_user,
         imap_password=imap_password,
         imap_port=imap_port,
+        imap_folder=imap_folder,
     )
 
 
@@ -82,6 +84,26 @@ def _get_account_email(client) -> str:
     return client.get_email_address()
 
 
+def _action_explanation(label: str, domain: str) -> str:
+    """Return a one-line plain-English explanation of what an action command does."""
+    lbl = label.lower()
+    if "review manually" in lbl:
+        return f"Previews what would be moved from {domain} — nothing is changed"
+    if "older than 90" in lbl:
+        return f"Moves emails older than 90 days from {domain} to Trash (recoverable)"
+    if "older than 30" in lbl:
+        return f"Moves emails older than 30 days from {domain} to Trash (recoverable)"
+    if "keep last" in lbl or "keep latest" in lbl:
+        parts = label.split()
+        n = parts[-1] if parts else "5"
+        return f"Moves all but the {n} most recent emails from {domain} to Trash (recoverable)"
+    if "mark" in lbl and "read" in lbl:
+        return f"Marks all emails from {domain} as read"
+    if "delete all" in lbl:
+        return f"Moves all emails from {domain} to Trash (recoverable)"
+    return ""
+
+
 def _is_first_stats_run() -> bool:
     """Returns True (and marks seen) the very first time stats completes successfully."""
     sentinel = DATA_DIR / ".stats_seen"
@@ -92,6 +114,31 @@ def _is_first_stats_run() -> bool:
     except OSError:
         pass
     return True
+
+
+def _handle_error(exc: Exception, verbose: bool = False) -> None:
+    """Translate an exception to a friendly message and exit."""
+    from mailtrim.core.errors import friendly_error
+
+    human_msg, fix_hint = friendly_error(exc)
+    console.print(f"\n[red]Error:[/red] {human_msg}")
+    if fix_hint:
+        console.print(f"  [cyan]{fix_hint}[/cyan]")
+    if verbose:
+        console.print(f"\n[dim]Details: {exc}[/dim]")
+    else:
+        console.print("[dim]  Add --verbose for technical details.[/dim]")
+    raise typer.Exit(1)
+
+
+def _record(command: str) -> None:
+    """Record command run in local usage stats (best-effort, never raises)."""
+    try:
+        from mailtrim.core.usage_stats import record_run
+
+        record_run(command)
+    except Exception:
+        pass
 
 
 # ── auth ─────────────────────────────────────────────────────────────────────
@@ -158,14 +205,20 @@ def stats(
         help="Mail scope to scan: 'inbox' (default) or 'anywhere' (includes archived, sent, all mail).",
     ),
     max_scan: int = typer.Option(
-        2000,
+        1000,
         "--max-scan",
-        help="Max emails to scan (default 2000). Raise to 5000+ for large mailboxes.",
+        help="Max emails to scan (default 1000). Raise to 5000+ for large mailboxes.",
     ),
     use_ai: bool = typer.Option(
         False,
         "--ai",
-        help="Enrich sender insights with local AI (requires llama.cpp at localhost:8080).",
+        help="[EXPERIMENTAL] Enrich sender insights with local AI (requires llama.cpp at localhost:8080).",
+    ),
+    ai_debug: bool = typer.Option(
+        False,
+        "--ai-debug",
+        help="Print AI call details, raw responses, and parse results.",
+        hidden=True,
     ),
     provider: str = typer.Option(
         "gmail",
@@ -174,8 +227,9 @@ def stats(
     ),
     imap_server: str = typer.Option("", "--imap-server", help="IMAP server hostname."),
     imap_user: str = typer.Option("", "--imap-user", help="IMAP login username."),
-    imap_password: str = typer.Option(
-        "", "--imap-password", help="IMAP app password.", hide_input=True
+    imap_port: int = typer.Option(993, "--imap-port", help="IMAP SSL port (default 993)."),
+    imap_folder: str = typer.Option(
+        "INBOX", "--imap-folder", help="IMAP folder to scan (default INBOX)."
     ),
     ai_backend: str = typer.Option(
         "llama",
@@ -184,12 +238,18 @@ def stats(
     ),
     ai_url: str = typer.Option("", "--ai-url", help="Override local AI server URL."),
     ai_model: str = typer.Option("phi3", "--ai-model", help="Model name (Ollama only)."),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Show full account summary and detailed insights."
+    ),
+    simple: bool = typer.Option(
+        False, "--simple", help="Plain-language output — no scores or tables."
+    ),
 ):
     """
     Inbox decision engine — reclaimable space, confidence-scored recommendations, top senders.
 
-    Tells you exactly what to delete, why it's safe, and how long it will take.
-    No AI required.
+    Tells you exactly what to move to Trash, why it's safe, and how long it will take.
+    No AI required. All deletions go to Trash — recoverable for 30 days.
 
     Examples:
       mailtrim stats
@@ -198,11 +258,14 @@ def stats(
       mailtrim stats --max-scan 5000    # scan more of a large mailbox
       mailtrim stats --share   # get a copyable one-liner to share
     """
+    _record("stats")
     import json as json_lib
     import time as _time
 
     from mailtrim.core.sender_stats import (
-        compute_confidence_score,
+        best_next_step,
+        classify_sender_risk,
+        confidence_description,
         confidence_reason,
         confidence_safety_label,
         fetch_sender_groups,
@@ -216,7 +279,8 @@ def stats(
         quick_win,
         reclaimable_mb,
         reclaimable_pct,
-        risk_tier_icon,
+        sender_risk_tier,
+        sender_risk_tier_from_conf,
     )
 
     if scope == "anywhere":
@@ -227,16 +291,32 @@ def stats(
         scope_label = "inbox"
 
     scan_start = _time.time()
-    client = _get_provider(
-        provider=provider,
-        imap_server=imap_server,
-        imap_user=imap_user,
-        imap_password=imap_password,
-    )
+
+    # Resolve IMAP password: env var → interactive prompt (never CLI flag)
+    import os as _os
+
+    imap_password = _os.environ.get("MAILTRIM_IMAP_PASSWORD", "")
+    if provider == "imap" and imap_user and not imap_password:
+        imap_password = typer.prompt(f"IMAP password for {imap_user}", hide_input=True, default="")
+
+    try:
+        client = _get_provider(
+            provider=provider,
+            imap_server=imap_server,
+            imap_user=imap_user,
+            imap_password=imap_password,
+            imap_port=imap_port,
+            imap_folder=imap_folder,
+        )
+    except Exception as exc:
+        _handle_error(exc, verbose=verbose)
 
     with Progress(SpinnerColumn(), TextColumn("{task.description}"), console=console) as p:
         t = p.add_task(f"Scanning {scope_label}…", total=None)
-        profile = client.get_profile()
+        try:
+            profile = client.get_profile()
+        except Exception as exc:
+            _handle_error(exc, verbose=verbose)
         p.update(t, description="Fetching top senders…")
         groups = fetch_sender_groups(
             client,
@@ -250,7 +330,8 @@ def stats(
         domain_groups = group_by_domain(groups)
         domain_map_lookup = {d.domain: d for d in domain_groups}
         insights = generate_insights(groups, domain_groups)
-        recommendations = generate_recommendations(groups, top_n=3, domain_map=domain_map_lookup)
+        recommendations = generate_recommendations(groups, top_n=5, domain_map=domain_map_lookup)
+        bns = best_next_step(recommendations)
         win = quick_win(recommendations)
         total_reclaimable = reclaimable_mb(recommendations)
         reclaim_pct = reclaimable_pct(total_reclaimable, insights.total_size_mb)
@@ -367,18 +448,27 @@ def stats(
         reclaim_pct=reclaim_pct,
         rec_count=len(recommendations),
         reclaimable_mb_val=total_reclaimable,
+        recommendations=recommendations,
     )
     console.print(f"  {headline}")
     console.print()
 
     # ── Reclaimable Space Banner ──────────────────────────────────────────────
     if total_reclaimable > 0:
-        pct_str = f" ({reclaim_pct}% of scanned inbox)" if reclaim_pct > 0 else ""
         total_rec_emails = sum(rec.sender.count for rec in recommendations)
         time_est = format_time_estimate(total_rec_emails)
+        if total_reclaimable < 10:
+            banner_lead = (
+                f"[bold green]Clean {total_rec_emails:,} unnecessary emails quickly[/bold green]"
+            )
+        else:
+            pct_str = f" ({reclaim_pct}% of scanned inbox)" if reclaim_pct > 0 else ""
+            banner_lead = (
+                f"[bold green]You can safely free ~{total_reclaimable} MB{pct_str}[/bold green]"
+            )
         console.print(
             Panel(
-                f"[bold green]You can safely free ~{total_reclaimable} MB{pct_str}[/bold green]\n"
+                f"{banner_lead}\n"
                 f"[dim]from your top {len(recommendations)} sender(s)  ·  "
                 f"Each cleanup takes {time_est}  ·  All deletions go to Trash — undo anytime[/dim]",
                 title="[bold]TOTAL RECLAIMABLE SPACE",
@@ -388,84 +478,139 @@ def stats(
         )
         console.print()
 
-    # ── Section 1: Account Summary ────────────────────────────────────────────
-    console.rule("[bold cyan]=== ACCOUNT SUMMARY ===", align="left")
-    console.print(
-        f"  [bold]{account_email}[/bold]\n"
-        f"  [dim]Total messages:[/dim]  {total_messages:,}   "
-        f"[dim]Total threads:[/dim] {total_threads:,}\n"
-        f"  [dim]{scope_label.capitalize()} scanned:[/dim]  {insights.total_scanned:,} messages  ·  "
-        f"[bold]{insights.total_size_mb} MB[/bold]\n"
-        f"  [dim]Unique senders:[/dim]  {insights.unique_senders}   "
-        f"[dim]Unique domains:[/dim] {insights.unique_domains}   "
-        f"[dim]Oldest email:[/dim] {insights.oldest_email_days}d ago"
-    )
-    if insights.total_scanned >= max_scan:
+    # ── Best Next Step ────────────────────────────────────────────────────────
+    if bns and bns.actions:
+        _bns_name = bns.sender.display_name[:40]
+        _bns_domain_grp = domain_map_lookup.get(bns.sender.domain)
+        _bns_count = _bns_domain_grp.count if _bns_domain_grp else bns.sender.count
+        _bns_action = bns.actions[0]
+        _bns_risk_label, _bns_icon, _bns_color = sender_risk_tier(bns.sender)
+        _bns_conf_desc = confidence_description(min(95, bns.confidence))
+        _bns_expl = _action_explanation(_bns_action.label, bns.sender.domain)
+        # Emphasise count over MB when savings are small (< 5 MB feels underwhelming)
+        if _bns_action.savings_mb >= 5:
+            _bns_value = f"[green]~{_bns_action.savings_mb} MB freed[/green]"
+        elif _bns_count > 0:
+            _bns_value = f"[green]Clean {_bns_count:,} low-value emails quickly[/green]"
+        else:
+            _bns_value = ""
         console.print(
-            f"\n  [yellow]⚠ Scan capped at {max_scan:,} — your mailbox may have more. "
-            f"Run [bold]mailtrim stats --max-scan 5000[/bold] to analyze further.[/yellow]"
+            Panel(
+                f"[bold]{_bns_name}[/bold]  [dim]{_bns_count} emails[/dim]\n"
+                + (f"  {_bns_value}\n" if _bns_value else "")
+                + f"  [cyan]{_bns_action.command}[/cyan]\n"
+                + (f"  [dim]{_bns_expl}[/dim]\n" if _bns_expl else "")
+                + f"  {_bns_icon} [{_bns_color}]{_bns_risk_label}[/{_bns_color}]  "
+                f"[dim]{_bns_conf_desc} ({min(95, bns.confidence)}%)[/dim]",
+                title="[bold green]=== BEST NEXT STEP ===",
+                border_style="green",
+                padding=(0, 2),
+            )
         )
-    if scope == "inbox" and total_messages > insights.total_scanned * 3:
+        console.print()
+    elif recommendations:
+        _top_rec = max(recommendations, key=lambda r: r.sender.impact_score)
         console.print(
-            f"\n  [dim]💡 {total_messages:,} total messages in your account vs "
-            f"{insights.total_scanned:,} scanned. Run [bold]mailtrim stats --scope anywhere[/bold] "
-            f"to include archived and sent mail.[/dim]"
+            Panel(
+                f"⚠ [bold]{_top_rec.sender.display_name[:45]}[/bold]  "
+                f"[dim]{_top_rec.sender.count} emails[/dim]\n"
+                "  Largest reclaimable item [yellow]needs review[/yellow] before deleting.",
+                title="[bold yellow]=== BEST NEXT STEP ===",
+                border_style="yellow",
+                padding=(0, 2),
+            )
         )
-    console.print()
+        console.print()
 
-    # ── Section 2: Key Insights ───────────────────────────────────────────────
-    console.rule("[bold cyan]=== KEY INSIGHTS ===", align="left")
-
-    if insights.top_storage:
-        g = insights.top_storage
+    # ── Section 1: Account Summary (verbose only) ─────────────────────────────
+    if verbose:
+        console.rule("[bold cyan]=== ACCOUNT SUMMARY ===", align="left")
         console.print(
-            f"  [bold red]🔥 Top storage hog:[/bold red]  {g.display_name[:40]}  "
-            f"[bold]{g.total_size_mb} MB[/bold] across {g.count} emails"
+            f"  [bold]{account_email}[/bold]\n"
+            f"  [dim]Total messages:[/dim]  {total_messages:,}   "
+            f"[dim]Total threads:[/dim] {total_threads:,}\n"
+            f"  [dim]{scope_label.capitalize()} scanned:[/dim]  {insights.total_scanned:,} messages  ·  "
+            f"[bold]{insights.total_size_mb} MB[/bold]\n"
+            f"  [dim]Unique senders:[/dim]  {insights.unique_senders}   "
+            f"[dim]Unique domains:[/dim] {insights.unique_domains}   "
+            f"[dim]Oldest email:[/dim] {insights.oldest_email_days}d ago"
         )
-
-    if insights.top_volume:
-        g = insights.top_volume
+    if max_scan > 1000:
         console.print(
-            f"  [bold yellow]📮 Most frequent:[/bold yellow]  {g.display_name[:40]}  "
-            f"[bold]{g.count} emails[/bold]  ·  {g.total_size_mb} MB"
+            f"\n  [dim]⚠ max-scan set to {max_scan:,} — large scans may take longer.[/dim]"
         )
+    if verbose:
+        if insights.total_scanned >= max_scan:
+            console.print(
+                f"\n  [yellow]⚠ Scan capped at {max_scan:,} — your mailbox may have more. "
+                f"Run [bold]mailtrim stats --max-scan 5000[/bold] to analyze further.[/yellow]"
+            )
+        if total_messages > 10_000:
+            console.print(
+                "\n  [dim]📬 Large mailbox detected — scanning recent inbox for quick wins[/dim]"
+            )
+        if scope == "inbox" and total_messages > insights.total_scanned * 3:
+            console.print(
+                f"\n  [dim]💡 {total_messages:,} total messages in your account vs "
+                f"{insights.total_scanned:,} scanned. Run [bold]mailtrim stats --scope anywhere[/bold] "
+                f"to include archived and sent mail.[/dim]"
+            )
+        console.print()
 
-    if insights.oldest:
-        g = insights.oldest
+    # ── Section 2: Key Insights (verbose only) ───────────────────────────────
+    if verbose:
+        console.rule("[bold cyan]=== KEY INSIGHTS ===", align="left")
+
+        if insights.top_storage:
+            g = insights.top_storage
+            console.print(
+                f"  [bold red]🔥 Top storage hog:[/bold red]  {g.display_name[:40]}  "
+                f"[bold]{g.total_size_mb} MB[/bold] across {g.count} emails"
+            )
+
+        if insights.top_volume:
+            g = insights.top_volume
+            console.print(
+                f"  [bold yellow]📮 Most frequent:[/bold yellow]  {g.display_name[:40]}  "
+                f"[bold]{g.count} emails[/bold]  ·  {g.total_size_mb} MB"
+            )
+
+        if insights.oldest:
+            g = insights.oldest
+            console.print(
+                f"  [bold blue]📅 Oldest clutter:[/bold blue]  {g.display_name[:40]}  "
+                f"sitting in inbox since [bold]{g.age_str}[/bold]"
+            )
+
+        if insights.multi_sender_domains:
+            top_multi = insights.multi_sender_domains[:3]
+            domain_parts = ", ".join(
+                f"[bold]{d.domain}[/bold] ({len(d.senders)} senders, {d.count} emails)"
+                for d in top_multi
+            )
+            console.print(f"  [bold green]🌐 Domain patterns:[/bold green]  {domain_parts}")
+
+        pct = insights.top_n_coverage_pct
+        top5_mb = insights.top_n_size_mb
         console.print(
-            f"  [bold blue]📅 Oldest clutter:[/bold blue]  {g.display_name[:40]}  "
-            f"sitting in inbox since [bold]{g.age_str}[/bold]"
+            f"\n  [dim]Top 5 senders account for[/dim] [bold]{pct}%[/bold] "
+            f"[dim]of scanned mail[/dim] ([bold]{top5_mb} MB[/bold])"
         )
+        console.print()
 
-    if insights.multi_sender_domains:
-        top_multi = insights.multi_sender_domains[:3]
-        domain_parts = ", ".join(
-            f"[bold]{d.domain}[/bold] ({len(d.senders)} senders, {d.count} emails)"
-            for d in top_multi
-        )
-        console.print(f"  [bold green]🌐 Domain patterns:[/bold green]  {domain_parts}")
-
-    pct = insights.top_n_coverage_pct
-    top5_mb = insights.top_n_size_mb
-    console.print(
-        f"\n  [dim]Top 5 senders account for[/dim] [bold]{pct}%[/bold] "
-        f"[dim]of scanned mail[/dim] ([bold]{top5_mb} MB[/bold])"
-    )
-    console.print()
-
-    # ── Quick Win ─────────────────────────────────────────────────────────────
+    # ── Quick Win — only show when it differs from BEST NEXT STEP ───────────
+    if win and win is bns:
+        win = None  # suppress duplicate — same sender already shown above
     if win and win.actions:
         first_action = win.actions[0]
-        safety = confidence_safety_label(win.confidence)
-        icon = risk_tier_icon(win.confidence)
+        _win_conf = min(95, win.confidence)
+        _win_label, _win_icon, _win_color = sender_risk_tier(win.sender)
         reason = confidence_reason(win.sender)
         _win_domain = domain_map_lookup.get(win.sender.domain)
         _win_count = _win_domain.count if _win_domain else win.sender.count
         _win_size_mb = _win_domain.total_size_mb if _win_domain else win.sender.total_size_mb
         time_est = format_time_estimate(_win_count)
-        safety_color = (
-            "green" if win.confidence >= 70 else "yellow" if win.confidence >= 40 else "red"
-        )
+        _win_conf_desc = confidence_description(_win_conf)
         savings_line = (
             f"  [yellow]→ {first_action.label}[/yellow]  "
             + (
@@ -481,9 +626,23 @@ def stats(
                 f"[dim]{_win_count} emails · {_win_size_mb} MB[/dim]\n\n"
                 + savings_line
                 + f"\n  [cyan]{first_action.command}[/cyan]\n\n"
-                f"  {icon} Confidence: [bold]{win.confidence}%[/bold]  ·  "
-                f"[{safety_color}]{safety}[/{safety_color}]"
+                f"  {_win_icon} [{_win_color}]{_win_label}[/{_win_color}]  "
+                f"[dim]{_win_conf_desc} ({_win_conf}%)[/dim]"
                 + (f"\n  [dim]Why: {reason}[/dim]" if reason != "limited signals" else ""),
+                title="[bold yellow]⚡ QUICK WIN — largest savings",
+                border_style="yellow",
+                padding=(0, 2),
+            )
+        )
+        console.print()
+    elif recommendations:
+        # All recommendations need review — surface the largest as a warning
+        _needs_review = max(recommendations, key=lambda r: r.sender.impact_score)
+        console.print(
+            Panel(
+                f"⚠ [bold]{_needs_review.sender.display_name[:45]}[/bold]  "
+                f"[dim]{_needs_review.sender.count} emails[/dim]\n"
+                "  Largest reclaimable item [yellow]needs review[/yellow] before deleting.",
                 title="[bold yellow]⚡ QUICK WIN",
                 border_style="yellow",
                 padding=(0, 2),
@@ -491,74 +650,137 @@ def stats(
         )
         console.print()
 
-    # ── Section 3: Top Senders ────────────────────────────────────────────────
-    console.rule("[bold cyan]=== TOP SENDERS ===", align="left")
+    # ── Section 3: Top Senders (verbose only) ────────────────────────────────
+    if verbose:
+        console.rule("[bold cyan]=== TOP SENDERS ===", align="left")
 
-    if groups:
-        table = Table(border_style="dim", show_header=True, header_style="bold", pad_edge=False)
-        table.add_column("#", width=3, style="dim")
-        table.add_column("Impact", width=12)
-        table.add_column("Sender", min_width=28)
-        table.add_column("Emails", justify="right", style="red bold", width=7)
-        table.add_column("Size", justify="right", width=9)
-        table.add_column("Oldest", width=12)
-        table.add_column("Risk", width=15)
-        table.add_column("Unsub", width=5, justify="center")
+        if groups:
+            table = Table(border_style="dim", show_header=True, header_style="bold", pad_edge=False)
+            table.add_column("#", width=3, style="dim")
+            table.add_column("Impact", width=12)
+            table.add_column("Sender", min_width=28)
+            table.add_column("Emails", justify="right", style="red bold", width=7)
+            table.add_column("Size", justify="right", width=9)
+            table.add_column("Oldest", width=12)
+            table.add_column("Risk", width=22)
+            table.add_column("Unsub", width=5, justify="center")
 
-        for i, g in enumerate(groups, 1):
-            ilabel = impact_label(g.impact_score)
-            label_color = {"High": "red", "Medium": "yellow", "Low": "dim"}.get(ilabel, "dim")
-            score_cell = f"[{label_color}]{g.impact_score} ({ilabel})[/{label_color}]"
-            name = g.display_name[:32]
-            size_str = (
-                f"{g.total_size_mb}MB"
-                if g.total_size_mb >= 0.1
-                else f"{g.total_size_bytes // 1024}KB"
+            for i, g in enumerate(groups, 1):
+                ilabel = impact_label(g.impact_score)
+                label_color = {"High": "red", "Medium": "yellow", "Low": "dim"}.get(ilabel, "dim")
+                score_cell = f"[{label_color}]{g.impact_score} ({ilabel})[/{label_color}]"
+                name = g.display_name[:32]
+                size_str = (
+                    f"{g.total_size_mb}MB"
+                    if g.total_size_mb >= 0.1
+                    else f"{g.total_size_bytes // 1024}KB"
+                )
+                _t_label, _t_icon, _t_color = sender_risk_tier(g)
+                risk_cell = f"{_t_icon} [{_t_color}]{_t_label}[/{_t_color}]"
+                unsub = "[green]✓[/green]" if g.has_unsubscribe else "[dim]–[/dim]"
+                table.add_row(
+                    str(i), score_cell, name, str(g.count), size_str, g.age_str, risk_cell, unsub
+                )
+
+            console.print(table)
+            console.print(
+                "[dim]  Impact = 60% storage + 40% volume (0–100)  ·  "
+                "Risk: 🟢 Safe to clean  🟡 Needs review  🔴 Sensitive / personal  ·  Unsub = List-Unsubscribe header[/dim]"
             )
-            conf = compute_confidence_score(g)
-            risk_icon = risk_tier_icon(conf)
-            safety = confidence_safety_label(conf)
-            risk_color = "green" if conf >= 70 else "yellow" if conf >= 40 else "red"
-            risk_cell = f"{risk_icon} [{risk_color}]{safety}[/{risk_color}]"
-            unsub = "[green]✓[/green]" if g.has_unsubscribe else "[dim]–[/dim]"
-            table.add_row(
-                str(i), score_cell, name, str(g.count), size_str, g.age_str, risk_cell, unsub
-            )
+        else:
+            console.print("  [dim]No senders found matching the query.[/dim]")
+        console.print()
 
-        console.print(table)
+    # ── Simple mode — plain-language output, no scores ────────────────────────
+    if simple:
+        if not recommendations:
+            console.print("  Your inbox looks clean — nothing obvious to remove right now.\n")
+        else:
+            console.print("  [bold]Here are 3 safe things you can do right now:[/bold]\n")
+            for i, rec in enumerate(recommendations[:3], 1):
+                g = rec.sender
+                _rec_domain = domain_map_lookup.get(g.domain)
+                _rec_count = _rec_domain.count if _rec_domain else g.count
+                risk_class = classify_sender_risk(g)
+                safety_note = (
+                    "safe to clean"
+                    if risk_class == "safe"
+                    else "worth a quick look first"
+                    if risk_class == "review"
+                    else "review manually — may be important"
+                )
+                if rec.actions:
+                    action = rec.actions[0]
+                    console.print(
+                        f"  [bold]{i}. {g.display_name[:45]}[/bold]  "
+                        f"[dim]({_rec_count} emails)[/dim]\n"
+                        f"     {safety_note}\n"
+                        f"     [cyan]{action.command}[/cyan]\n"
+                    )
+            console.print(
+                "[dim]  All emails moved to Trash — undo anytime with: mailtrim undo[/dim]\n"
+            )
         console.print(
-            "[dim]  Impact = 60% storage + 40% volume (0–100)  ·  "
-            "Risk: 🟢 Safe  🟡 Low risk  🔴 Review first  ·  Unsub = List-Unsubscribe header[/dim]"
+            "[dim]  Add --verbose for full details · mailtrim purge — interactive cleanup[/dim]\n"
         )
-    else:
-        console.print("  [dim]No senders found matching the query.[/dim]")
-    console.print()
+        return
 
     # ── Section 4: Recommended Actions ───────────────────────────────────────
     console.rule("[bold cyan]=== RECOMMENDED ACTIONS ===", align="left")
 
-    # Optional local-AI enrichment — only for senders where AI adds signal.
+    # Optional local-AI enrichment — always runs on all top recommendations.
     ai_insights: dict[str, dict] = {}
     if use_ai and recommendations:
         from mailtrim.core.llm import (
             analyze_batch,
             confidence_delta,
-            should_analyze,
         )
 
-        eligible = [
-            rec
-            for rec in recommendations
-            if should_analyze(rec.confidence, rec.sender.count, rec.sender.sender_email)
-        ]
-        if eligible:
-            with console.status("[dim][AI] Analyzing senders via local model…[/dim]"):
-                texts = ["\n".join(rec.sender.sample_subjects) for rec in eligible]
-                keys = [rec.sender.sender_email for rec in eligible]
-                _ai_client_override = _get_ai_client_opt(ai_backend, ai_url, ai_model)
-                results = analyze_batch(texts, cache_keys=keys, ai_client=_ai_client_override)
-            for rec, result in zip(eligible, results):
-                ai_insights[rec.sender.sender_email] = result
+        # Always run AI on all top recommendations — they are exactly the senders where
+        # a second opinion matters most. The old should_analyze filter was blocking all of
+        # them because high-confidence senders were being skipped.
+        eligible = recommendations
+
+        if ai_debug:
+            import logging as _logging
+
+            _ai_handler = _logging.StreamHandler()
+            _ai_handler.setFormatter(_logging.Formatter("[AI DEBUG] %(name)s — %(message)s"))
+            for _mod in ("mailtrim.core.ai.client", "mailtrim.core.llm"):
+                _log = _logging.getLogger(_mod)
+                _log.setLevel(_logging.DEBUG)
+                _log.addHandler(_ai_handler)
+
+            console.print(
+                f"[dim][AI debug] Running AI on {len(eligible)} sender(s): "
+                + ", ".join(r.sender.sender_email for r in eligible)
+                + "[/dim]"
+            )
+            for rec in eligible:
+                _text = f"From: {rec.sender.sender_name or rec.sender.sender_email}\n" + "\n".join(
+                    rec.sender.sample_subjects[:3]
+                )
+                console.print(
+                    f"[dim][AI debug] prompt for {rec.sender.sender_email}:\n{_text}[/dim]"
+                )
+
+        with console.status("[dim][AI] Analyzing senders via local model…[/dim]"):
+            texts = [
+                f"From: {rec.sender.sender_name or rec.sender.sender_email}\n"
+                + "\n".join(rec.sender.sample_subjects[:3])
+                for rec in eligible
+            ]
+            keys = [rec.sender.sender_email for rec in eligible]
+            _ai_client_override = _get_ai_client_opt(ai_backend, ai_url, ai_model)
+            results = analyze_batch(texts, cache_keys=keys, ai_client=_ai_client_override)
+
+        for rec, result in zip(eligible, results):
+            if ai_debug:
+                console.print(
+                    f"[dim][AI debug] {rec.sender.sender_email}: "
+                    f"{'parsed OK → ' + str(result) if result else 'no result (parse failed or backend unavailable)'}[/dim]"
+                )
+            ai_insights[rec.sender.sender_email] = result
 
         if ai_insights:
             from mailtrim.core.llm import apply_impact_nudge
@@ -568,7 +790,31 @@ def stats(
     if recommendations:
         from mailtrim.core.llm import format_ai_line  # always available
 
-        for i, rec in enumerate(recommendations, 1):
+        # AI summary block — one concise insight line per sender with AI data
+        if use_ai and ai_insights:
+            _AI_CAT_DESC: dict[str, str] = {
+                "promo": "looks promotional",
+                "spam": "appears spam-like",
+                "update": "appears to be automated updates",
+                "important": "may contain important content",
+            }
+            _ai_lines = []
+            for rec in recommendations:
+                _ai = ai_insights.get(rec.sender.sender_email, {})
+                _cat = _ai.get("category", "")
+                _desc = _AI_CAT_DESC.get(_cat, "")
+                if not _desc:
+                    continue
+                # Sensitive senders get a stronger warning regardless of AI category
+                if classify_sender_risk(rec.sender) == "sensitive":
+                    _desc = "may be important — review before deleting"
+                _ai_lines.append(f"  [dim][AI] {rec.sender.display_name[:30]} {_desc}[/dim]")
+            for _line in _ai_lines[:3]:
+                console.print(_line)
+            if _ai_lines:
+                console.print()
+
+        for i, rec in enumerate(recommendations[:3], 1):
             g = rec.sender
             _rec_domain = domain_map_lookup.get(g.domain)
             _rec_count = _rec_domain.count if _rec_domain else g.count
@@ -577,18 +823,12 @@ def stats(
             rule_conf = rec.confidence
 
             # Compute adjusted confidence without mutating rec.confidence.
+            # Cap at 95 — 100% implies certainty we never have.
             delta = confidence_delta(ai) if (use_ai and ai) else 0
-            display_confidence = max(0, min(100, rule_conf + delta))
+            display_confidence = max(0, min(95, rule_conf + delta))
 
-            safety = confidence_safety_label(display_confidence)
-            safety_color = (
-                "green"
-                if display_confidence >= 70
-                else "yellow"
-                if display_confidence >= 40
-                else "red"
-            )
-            icon = risk_tier_icon(display_confidence)
+            safety, icon, safety_color = sender_risk_tier_from_conf(g, display_confidence)
+            conf_desc = confidence_description(display_confidence)
 
             # Reason hint: prefer AI category phrase, fall back to rule-based.
             if use_ai and ai:
@@ -623,17 +863,18 @@ def stats(
             console.print(
                 f"  [bold]{i}. {g.display_name[:40]}[/bold]  "
                 f"[dim]{_rec_count} emails · {_rec_size_mb} MB · {g.age_str}[/dim]\n"
-                f"  {icon} Confidence: {conf_str}  "
-                f"[{safety_color}]{safety}[/{safety_color}]{reason_hint}"
+                f"  {icon} [{safety_color}]{safety}[/{safety_color}]  "
+                f"Confidence: {conf_str} [dim]— {conf_desc}[/dim]{reason_hint}"
             )
             if use_ai and ai:
                 console.print(f"  [dim]{format_ai_line(ai)}[/dim]")
             for action in rec.actions:
-                savings_str = (
-                    f"[green]~{action.savings_mb} MB freed[/green]"
-                    if action.savings_mb > 0
-                    else "[dim]no storage change[/dim]"
-                )
+                if action.savings_mb > 0:
+                    savings_str = f"[green]~{action.savings_mb} MB freed[/green]"
+                elif "review" in action.label.lower():
+                    savings_str = "[yellow]Review manually before deciding[/yellow]"
+                else:
+                    savings_str = "[dim]Preview items safely before deleting[/dim]"
                 tilde = "" if action.savings_exact else "~"
                 time_est = format_time_estimate(_rec_count)
                 console.print(
@@ -641,17 +882,149 @@ def stats(
                     f"{tilde}{savings_str}  [dim]takes {time_est}[/dim]"
                 )
                 console.print(f"      [cyan]{action.command}[/cyan]")
+                _expl = _action_explanation(action.label, g.domain)
+                if _expl:
+                    console.print(f"      [dim]{_expl}[/dim]")
             console.print()
-        console.print("[dim]  All deletions go to Trash — undo anytime with: mailtrim undo[/dim]\n")
+        console.print(
+            "[dim]  All emails moved to Trash (recoverable) — undo anytime with: mailtrim undo[/dim]\n"
+        )
     else:
         console.print("  [dim]Not enough data for recommendations.[/dim]\n")
 
     console.print(
-        "[dim]  Or explore interactively:[/dim]\n"
-        "  [cyan]mailtrim purge[/cyan]              — pick senders to delete interactively\n"
+        "[dim]  Next steps:[/dim]\n"
+        "  [cyan]mailtrim purge[/cyan]              — pick senders to move to Trash interactively\n"
         "  [cyan]mailtrim stats --sort size[/cyan]  — re-sort by storage\n"
-        "  [cyan]mailtrim stats --share[/cyan]      — copy a shareable summary\n"
-        "  [cyan]mailtrim triage[/cyan]             — AI-powered inbox classification\n"
+        "  [cyan]mailtrim stats --verbose[/cyan]    — full account summary + all senders\n"
+        "  [cyan]mailtrim stats --simple[/cyan]     — plain-language view, no scores\n"
+        "  [cyan]mailtrim quickstart[/cyan]         — guided first cleanup\n"
+    )
+
+
+# ── quickstart ───────────────────────────────────────────────────────────────
+
+
+@app.command()
+def quickstart():
+    """
+    Guided first cleanup — checks auth, scans inbox, and suggests your first safe action.
+
+    Perfect for first-time users. Run this before anything else.
+    """
+    import time as _time
+
+    from mailtrim.core.sender_stats import (
+        best_next_step,
+        classify_sender_risk,
+        fetch_sender_groups,
+        generate_recommendations,
+        group_by_domain,
+        reclaimable_mb,
+    )
+
+    # Step 1: Check auth
+    console.print()
+    console.print(
+        Panel.fit(
+            "[bold cyan]mailtrim quickstart[/bold cyan]\n\n"
+            "This will scan your inbox and suggest your first safe cleanup.\n"
+            "[dim]Nothing is deleted until you run the suggested command.[/dim]",
+            border_style="cyan",
+        )
+    )
+    console.print()
+
+    try:
+        client = _get_client()
+        account_email = _get_account_email(client)
+        console.print(f"[green]✓ Authenticated[/green] as [bold]{account_email}[/bold]")
+    except Exception:
+        console.print(
+            "[red]✗ Not authenticated.[/red]\n\n"
+            "Run [cyan]mailtrim auth[/cyan] first to connect your Gmail account.\n"
+        )
+        raise typer.Exit(1)
+
+    # Step 2: Quick scan
+    console.print()
+    _t0 = _time.time()
+    with console.status("Scanning your inbox for quick wins…"):
+        groups = fetch_sender_groups(
+            client,
+            query="in:inbox",
+            max_messages=500,
+            min_count=2,
+            top_n=20,
+            sort_by="score",
+        )
+        domain_groups = group_by_domain(groups)
+        domain_map_lookup = {d.domain: d for d in domain_groups}
+        recommendations = generate_recommendations(groups, top_n=5, domain_map=domain_map_lookup)
+        bns = best_next_step(recommendations)
+        total_reclaimable = reclaimable_mb(recommendations)
+
+    elapsed = round(_time.time() - _t0, 1)
+    console.print(f"[dim]  Scanned {len(groups)} senders in {elapsed}s[/dim]\n")
+
+    # Step 3: Explain what we found
+    if not recommendations:
+        console.print(
+            Panel(
+                "[green]Your inbox looks clean![/green]\n\n"
+                "Nothing obvious to remove right now.\n"
+                "[dim]Run [bold]mailtrim stats[/bold] anytime for a full analysis.[/dim]",
+                border_style="green",
+            )
+        )
+        return
+
+    console.print(
+        Panel(
+            f"Found [bold]{len(recommendations)}[/bold] sender(s) worth reviewing  ·  "
+            f"up to [bold green]~{total_reclaimable} MB[/bold green] reclaimable\n\n"
+            "[dim]All emails go to Trash (recoverable for 30 days). Nothing permanent.[/dim]",
+            title="[bold]What we found",
+            border_style="cyan",
+        )
+    )
+    console.print()
+
+    # Step 4: Surface the single best first action
+    if bns and bns.actions:
+        g = bns.sender
+        _domain_grp = domain_map_lookup.get(g.domain)
+        _count = _domain_grp.count if _domain_grp else g.count
+        action = bns.actions[0]
+        risk_class = classify_sender_risk(g)
+        safety_msg = (
+            "This sender looks safe to clean — unsubscribe-style mail."
+            if risk_class == "safe"
+            else "This sender looks low-risk but worth a quick look first."
+            if risk_class == "review"
+            else "This sender may have important mail — review before deleting."
+        )
+
+        console.print(
+            Panel(
+                f"[bold]Your first suggested cleanup:[/bold]\n\n"
+                f"  [bold]{g.display_name[:50]}[/bold]  [dim]({_count} emails)[/dim]\n\n"
+                f"  {safety_msg}\n\n"
+                f"  Run this command:\n"
+                f"  [bold cyan]{action.command}[/bold cyan]\n\n"
+                f"[dim]  After reviewing, you can run it without --dry-run to move emails to Trash.[/dim]",
+                title="[bold green]Suggested first action",
+                border_style="green",
+                padding=(0, 2),
+            )
+        )
+        console.print()
+
+    console.print(
+        "[dim]  Ready for more? Try:[/dim]\n"
+        "  [cyan]mailtrim stats[/cyan]          — full analysis with all recommendations\n"
+        "  [cyan]mailtrim purge[/cyan]          — interactive cleanup picker\n"
+        "  [cyan]mailtrim stats --simple[/cyan] — plain-language view\n"
     )
 
 
@@ -990,10 +1363,19 @@ def undo(
             console.print("[dim]Cancelled.[/dim]")
             return
 
-    with console.status("Reversing operation..."):
+    with Progress(SpinnerColumn(), TextColumn("{task.description}"), console=console) as prog:
+        t = prog.add_task("Restoring emails…", total=None)
         count = engine.undo(log_id)
+        prog.update(t, description="Done.")
 
-    console.print(f"[green]Restored {count} messages.[/green]")
+    try:
+        from mailtrim.core.usage_stats import record_undo
+
+        record_undo(restored=count)
+    except Exception:
+        pass
+
+    console.print(f"[green]✓ Restored {count} emails.[/green]")
 
     # Offer to protect the senders so this doesn't happen again
     senders = entry.op_metadata.get("senders", [])
@@ -1026,7 +1408,7 @@ def follow_up(
     sync_replies: bool = typer.Option(False, "--sync", "-s", help="Sync reply detection."),
 ):
     """
-    Track an email for follow-up. Only reminds you if they haven't replied.
+    [EXPERIMENTAL] Track an email for follow-up. Only reminds you if they haven't replied.
 
     Examples:
       mailtrim follow-up 18bca72... --days 5
@@ -1104,7 +1486,7 @@ def avoid(
     no_insights: bool = typer.Option(False, "--no-insights", help="Skip AI insight generation."),
 ):
     """
-    Show emails you've been putting off — viewed multiple times but never acted on.
+    [EXPERIMENTAL] Show emails you've been putting off — viewed multiple times but never acted on.
     AI explains why you might be avoiding them and suggests one action.
     """
     from mailtrim.core.avoidance import AvoidanceDetector
@@ -1323,7 +1705,7 @@ def rules(
 
 @app.command()
 def digest():
-    """Generate your weekly inbox digest — insights, action items, and one cleanup suggestion."""
+    """[EXPERIMENTAL] Generate your weekly inbox digest — insights, action items, and one cleanup suggestion."""
     from collections import Counter
 
     from mailtrim.core.avoidance import AvoidanceDetector
@@ -1410,13 +1792,17 @@ def _print_cleanup_complete(
         border = "red"
         title = "🗑  Cleanup Complete"
     else:
-        undo_hint = f"  [dim]Undo: mailtrim undo {undo_id}[/dim]" if undo_id is not None else ""
+        undo_line = (
+            f"\n  [bold]Undo anytime:[/bold] [cyan]mailtrim undo {undo_id}[/cyan]"
+            if undo_id is not None
+            else "\n  [cyan]mailtrim undo[/cyan] — see recent operations"
+        )
         body = (
-            f"Moved [bold]{email_count:,} emails[/bold] to Trash  ·  "
+            f"[green]✓ Moved {email_count:,} emails to Trash[/green]  ·  "
             f"freed [bold green]~{freed_mb} MB[/bold green]  ·  took [bold]{elapsed_seconds}s[/bold]\n"
             f"Senders: [dim]{names_str}[/dim]\n"
             f"[dim]Gmail Trash shows threads, not messages — visible count there will be lower.[/dim]"
-            + undo_hint
+            + undo_line
         )
         border = "green"
         title = "🎉  Cleanup Complete"
@@ -1469,7 +1855,16 @@ def purge(
         False, "--unsub", help="Also unsubscribe from selected senders."
     ),
     permanent: bool = typer.Option(
-        False, "--permanent", help="Permanently delete (skip Trash). IRREVERSIBLE."
+        False,
+        "--permanent",
+        help="Permanently delete (skip Trash). IRREVERSIBLE.",
+        hidden=True,
+    ),
+    i_understand_permanent: bool = typer.Option(
+        False,
+        "--i-understand-permanent",
+        help="Required second flag when using --permanent.",
+        hidden=True,
     ),
     json_output: bool = typer.Option(
         False, "--json", help="Output sender list as JSON and exit (no deletion)."
@@ -1491,8 +1886,9 @@ def purge(
     provider: str = typer.Option("gmail", "--provider", help="Email provider: gmail or imap."),
     imap_server: str = typer.Option("", "--imap-server", help="IMAP server hostname."),
     imap_user: str = typer.Option("", "--imap-user", help="IMAP login username."),
-    imap_password: str = typer.Option(
-        "", "--imap-password", help="IMAP app password.", hide_input=True
+    imap_port: int = typer.Option(993, "--imap-port", help="IMAP SSL port (default 993)."),
+    imap_folder: str = typer.Option(
+        "INBOX", "--imap-folder", help="IMAP folder to scan (default INBOX)."
     ),
     ai_backend: str = typer.Option(
         "llama", "--ai-backend", help="Local AI backend: llama or ollama."
@@ -1501,10 +1897,10 @@ def purge(
     ai_model: str = typer.Option("phi3", "--ai-model", help="Model name (Ollama only)."),
 ):
     """
-    Show top email offenders and bulk-delete the ones you choose.
+    Move top email senders to Trash — with a 30-day undo window.
 
     Scans your promotions/newsletters, ranks senders, lets you pick which
-    ones to delete — with a 30-day undo window.
+    ones to move to Trash. All deletions are recoverable for 30 days.
 
     Examples:
       mailtrim purge
@@ -1516,6 +1912,8 @@ def purge(
       mailtrim purge --query "category:promotions" --top 20
       mailtrim purge --unsub   # also unsubscribe while deleting
     """
+    _record("purge")
+    import os as _os
     import time as _time
 
     from mailtrim.core.sender_stats import compute_confidence_score, fetch_sender_groups
@@ -1523,11 +1921,31 @@ def purge(
     from mailtrim.core.unsubscribe import UnsubscribeEngine
     from mailtrim.core.validation import validate_domain, validate_older_than
 
+    # Guard: --permanent requires the explicit confirmation flag to prevent accidents.
+    if permanent and not i_understand_permanent:
+        console.print(
+            Panel(
+                "[bold red]--permanent requires --i-understand-permanent[/bold red]\n\n"
+                "Permanent deletion bypasses Trash and cannot be undone.\n"
+                "If you really mean it, add [bold]--i-understand-permanent[/bold] to your command.\n\n"
+                "[dim]Tip: omit --permanent to move to Trash instead (recoverable for 30 days).[/dim]",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(1)
+
+    # Resolve IMAP password: env var → interactive prompt (never CLI flag)
+    imap_password = _os.environ.get("MAILTRIM_IMAP_PASSWORD", "")
+    if provider == "imap" and imap_user and not imap_password:
+        imap_password = typer.prompt(f"IMAP password for {imap_user}", hide_input=True, default="")
+
     client = _get_provider(
         provider=provider,
         imap_server=imap_server,
         imap_user=imap_user,
         imap_password=imap_password,
+        imap_port=imap_port,
+        imap_folder=imap_folder,
     )
     account_email = _get_account_email(client)
 
@@ -1746,7 +2164,10 @@ def purge(
         ]
         if eligible_groups:
             with console.status("[dim][AI] Analyzing senders via local model…[/dim]"):
-                texts = ["\n".join(g.sample_subjects) for g in eligible_groups]
+                texts = [
+                    f"From: {g.sender_name or g.sender_email}\n" + "\n".join(g.sample_subjects[:3])
+                    for g in eligible_groups
+                ]
                 keys = [g.sender_email for g in eligible_groups]
                 _purge_ai_client = _get_ai_client_opt(ai_backend, ai_url, ai_model)
                 ai_results = analyze_batch(texts, cache_keys=keys, ai_client=_purge_ai_client)
@@ -1811,7 +2232,7 @@ def purge(
                 action = ai.get("action", "")
                 rule_conf = compute_confidence_score(g)
                 delta = confidence_delta(ai)
-                adj_conf = max(0, min(100, rule_conf + delta))
+                adj_conf = max(0, min(95, rule_conf + delta))
                 sign = "+" if delta > 0 else ""
                 delta_str = f"{sign}{delta}%" if delta != 0 else ""
                 ai_cell = (
@@ -1860,20 +2281,21 @@ def purge(
     if permanent:
         console.print(
             Panel(
-                f"[bold red]WARNING — THIS CANNOT BE UNDONE[/bold red]\n\n"
-                f"You are about to [bold]permanently delete {sel_msgs} emails[/bold] "
+                f"[bold red]⚠  PERMANENT DELETION — THIS CANNOT BE UNDONE  ⚠[/bold red]\n\n"
+                f"You are about to [bold]permanently erase {sel_msgs} emails[/bold] "
                 f"from {len(selected)} sender(s).\n"
-                f"They will NOT go to Trash. There is no recovery.\n\n"
-                f"[dim]Remove --permanent to move to Trash instead (recoverable for 30 days).[/dim]",
+                f"They will [bold]NOT[/bold] go to Trash. There is [bold]no recovery, no undo[/bold].\n\n"
+                f"[dim]Omit --permanent to move to Trash instead (recoverable for 30 days).[/dim]",
                 border_style="red",
+                title="[bold red]IRREVERSIBLE ACTION",
             )
         )
         if not yes:
-            # Require typing "delete permanently" to confirm — not just Enter
+            # Require typing "DELETE FOREVER" to confirm — not just Enter
             answer = Prompt.ask(
-                '[bold red]Type "delete permanently" to confirm, or anything else to cancel[/bold red]'
+                '[bold red]Type "DELETE FOREVER" to confirm, or anything else to cancel[/bold red]'
             )
-            if answer.strip().lower() != "delete permanently":
+            if answer.strip() != "DELETE FOREVER":
                 console.print("[dim]Cancelled.[/dim]")
                 return
     else:
@@ -1925,6 +2347,15 @@ def purge(
 
     freed_mb = round(sum(g.total_size_bytes for g in selected) / (1024 * 1024), 1)
     sender_names = [g.display_name[:30] for g in selected[:3]]
+
+    if not permanent:
+        try:
+            from mailtrim.core.usage_stats import record_emails_trashed
+
+            record_emails_trashed(deleted)
+        except Exception:
+            pass
+
     _print_cleanup_complete(
         console=console,
         freed_mb=freed_mb,
@@ -2017,6 +2448,92 @@ def protect(
         f"[green]Protected:[/green] [bold]{sender}[/bold]\n"
         "[dim]This sender will no longer appear in purge lists.[/dim]"
     )
+
+
+# ── doctor ────────────────────────────────────────────────────────────────────
+
+
+@app.command()
+def doctor(
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show full error details."),
+    ai: bool = typer.Option(False, "--ai", help="Also check local AI endpoint."),
+):
+    """
+    Check that mailtrim is configured correctly and ready to use.
+
+    Verifies auth, Gmail connection, storage, and optional AI endpoint.
+    Run this first if something isn't working.
+
+    Examples:
+      mailtrim doctor
+      mailtrim doctor --ai   # also check local AI endpoint
+    """
+    from mailtrim.core.diagnostics import run_all
+
+    console.print()
+    console.print(
+        Panel.fit(
+            f"[bold cyan]mailtrim doctor[/bold cyan]  [dim]v{__version__}[/dim]\n"
+            "[dim]Running system checks…[/dim]",
+            border_style="cyan",
+        )
+    )
+    console.print()
+
+    results = run_all(include_optional=ai)
+
+    required_ok = 0
+    required_fail = 0
+    optional_warn = 0
+
+    for r in results:
+        if r.ok:
+            icon = "[green]✓[/green]"
+            if r.optional:
+                optional_warn = optional_warn  # stays 0 — it passed
+            else:
+                required_ok += 1
+        elif r.optional:
+            icon = "[yellow]⚠[/yellow]"
+            optional_warn += 1
+        else:
+            icon = "[red]✗[/red]"
+            required_fail += 1
+
+        console.print(f"  {icon}  {r.name}")
+        if not r.ok:
+            console.print(f"     [dim]{r.message}[/dim]")
+            if r.fix:
+                console.print(f"     [cyan]Fix: {r.fix}[/cyan]")
+        elif verbose:
+            console.print(f"     [dim]{r.message}[/dim]")
+
+    console.print()
+    if required_fail == 0:
+        status_text = "[bold green]Ready[/bold green]"
+        border = "green"
+        hint = "You're all set — try: mailtrim quickstart"
+    else:
+        status_text = "[bold red]Needs Attention[/bold red]"
+        border = "red"
+        hint = "Fix the issues above, then re-run: mailtrim doctor"
+
+    if optional_warn:
+        note = f"  [dim]{optional_warn} optional check(s) not passing — these won't block usage.[/dim]\n"
+    else:
+        note = ""
+
+    console.print(
+        Panel(
+            f"Overall status: {status_text}\n{note}  [dim]{hint}[/dim]",
+            border_style=border,
+            padding=(0, 2),
+        )
+    )
+    console.print()
+
+    if required_fail > 0:
+        raise typer.Exit(1)
 
 
 # ── version ───────────────────────────────────────────────────────────────────

--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -134,6 +134,11 @@ def stats(
         "--max-scan",
         help="Max emails to scan (default 2000). Raise to 5000+ for large mailboxes.",
     ),
+    use_ai: bool = typer.Option(
+        False,
+        "--ai",
+        help="Enrich sender insights with local AI (requires llama.cpp at localhost:8080).",
+    ),
 ):
     """
     Inbox decision engine — reclaimable space, confidence-scored recommendations, top senders.
@@ -193,8 +198,9 @@ def stats(
         )
         p.update(t, description="Scoring recommendations…")
         domain_groups = group_by_domain(groups)
+        domain_map_lookup = {d.domain: d for d in domain_groups}
         insights = generate_insights(groups, domain_groups)
-        recommendations = generate_recommendations(groups, top_n=3)
+        recommendations = generate_recommendations(groups, top_n=3, domain_map=domain_map_lookup)
         win = quick_win(recommendations)
         total_reclaimable = reclaimable_mb(recommendations)
         reclaim_pct = reclaimable_pct(total_reclaimable, insights.total_size_mb)
@@ -206,7 +212,10 @@ def stats(
 
     # ── Share mode ────────────────────────────────────────────────────────────
     if share:
-        rec_email_count = sum(rec.sender.count for rec in recommendations)
+        rec_email_count = sum(
+            (domain_map_lookup.get(rec.sender.domain) or rec.sender).count
+            for rec in recommendations
+        )
         viral = generate_viral_share_text(
             freed_mb=total_reclaimable,
             sender_count=len(recommendations),
@@ -400,7 +409,10 @@ def stats(
         safety = confidence_safety_label(win.confidence)
         icon = risk_tier_icon(win.confidence)
         reason = confidence_reason(win.sender)
-        time_est = format_time_estimate(win.sender.count)
+        _win_domain = domain_map_lookup.get(win.sender.domain)
+        _win_count = _win_domain.count if _win_domain else win.sender.count
+        _win_size_mb = _win_domain.total_size_mb if _win_domain else win.sender.total_size_mb
+        time_est = format_time_estimate(_win_count)
         safety_color = (
             "green" if win.confidence >= 70 else "yellow" if win.confidence >= 40 else "red"
         )
@@ -416,7 +428,7 @@ def stats(
         console.print(
             Panel(
                 f"[bold]{win.sender.display_name[:45]}[/bold]  "
-                f"[dim]{win.sender.count} emails · {win.sender.total_size_mb} MB[/dim]\n\n"
+                f"[dim]{_win_count} emails · {_win_size_mb} MB[/dim]\n\n"
                 + savings_line
                 + f"\n  [cyan]{first_action.command}[/cyan]\n\n"
                 f"  {icon} Confidence: [bold]{win.confidence}%[/bold]  ·  "
@@ -475,22 +487,95 @@ def stats(
     # ── Section 4: Recommended Actions ───────────────────────────────────────
     console.rule("[bold cyan]=== RECOMMENDED ACTIONS ===", align="left")
 
+    # Optional local-AI enrichment — only for senders where AI adds signal.
+    ai_insights: dict[str, dict] = {}
+    if use_ai and recommendations:
+        from mailtrim.core.llm import (
+            CATEGORY_ICON,
+            analyze_batch,
+            confidence_delta,
+            should_analyze,
+        )
+
+        eligible = [
+            rec for rec in recommendations
+            if should_analyze(rec.confidence, rec.sender.count, rec.sender.sender_email)
+        ]
+        if eligible:
+            with console.status("[dim][AI] Analyzing senders via local model…[/dim]"):
+                texts = ["\n".join(rec.sender.sample_subjects) for rec in eligible]
+                keys = [rec.sender.sender_email for rec in eligible]
+                results = analyze_batch(texts, cache_keys=keys)
+            for rec, result in zip(eligible, results):
+                ai_insights[rec.sender.sender_email] = result
+
+        if ai_insights:
+            from mailtrim.core.llm import apply_impact_nudge
+            apply_impact_nudge(groups, ai_insights)
+
     if recommendations:
+        from mailtrim.core.llm import format_ai_line  # always available
+
         for i, rec in enumerate(recommendations, 1):
             g = rec.sender
-            safety = confidence_safety_label(rec.confidence)
+            _rec_domain = domain_map_lookup.get(g.domain)
+            _rec_count = _rec_domain.count if _rec_domain else g.count
+            _rec_size_mb = _rec_domain.total_size_mb if _rec_domain else g.total_size_mb
+            ai = ai_insights.get(g.sender_email, {})
+            rule_conf = rec.confidence
+
+            # Compute adjusted confidence without mutating rec.confidence.
+            delta = confidence_delta(ai) if (use_ai and ai) else 0
+            display_confidence = max(0, min(100, rule_conf + delta))
+
+            safety = confidence_safety_label(display_confidence)
             safety_color = (
-                "green" if rec.confidence >= 70 else "yellow" if rec.confidence >= 40 else "red"
+                "green"
+                if display_confidence >= 70
+                else "yellow"
+                if display_confidence >= 40
+                else "red"
             )
-            icon = risk_tier_icon(rec.confidence)
-            reason = confidence_reason(g)
-            reason_hint = f" [dim]({reason})[/dim]" if reason != "limited signals" else ""
+            icon = risk_tier_icon(display_confidence)
+
+            # Reason hint: prefer AI category phrase, fall back to rule-based.
+            if use_ai and ai:
+                ai_cat = ai.get("category", "")
+                _cat_phrase = {
+                    "promo": "promo pattern",
+                    "spam": "spam signals",
+                    "update": "automated updates",
+                    "important": "important mail",
+                }.get(ai_cat, "")
+                rule_reason = confidence_reason(g)
+                if _cat_phrase and rule_reason != "limited signals":
+                    reason_text = f"{_cat_phrase} + {rule_reason}"[:50]
+                elif _cat_phrase:
+                    reason_text = _cat_phrase
+                else:
+                    reason_text = rule_reason
+            else:
+                reason_text = confidence_reason(g)
+            reason_hint = f" [dim]({reason_text})[/dim]" if reason_text != "limited signals" else ""
+
+            # Confidence line: show arrow + delta when AI adjusted it.
+            if use_ai and ai and delta != 0:
+                sign = "+" if delta > 0 else ""
+                conf_str = (
+                    f"[dim]{rule_conf}%[/dim] → [bold]{display_confidence}%[/bold] "
+                    f"[dim]({sign}{delta}% AI)[/dim]"
+                )
+            else:
+                conf_str = f"[bold]{display_confidence}%[/bold]"
+
             console.print(
                 f"  [bold]{i}. {g.display_name[:40]}[/bold]  "
-                f"[dim]{g.count} emails · {g.total_size_mb} MB · {g.age_str}[/dim]\n"
-                f"  {icon} Confidence: [bold]{rec.confidence}%[/bold]  "
+                f"[dim]{_rec_count} emails · {_rec_size_mb} MB · {g.age_str}[/dim]\n"
+                f"  {icon} Confidence: {conf_str}  "
                 f"[{safety_color}]{safety}[/{safety_color}]{reason_hint}"
             )
+            if use_ai and ai:
+                console.print(f"  [dim]{format_ai_line(ai)}[/dim]")
             for action in rec.actions:
                 savings_str = (
                     f"[green]~{action.savings_mb} MB freed[/green]"
@@ -498,7 +583,7 @@ def stats(
                     else "[dim]no storage change[/dim]"
                 )
                 tilde = "" if action.savings_exact else "~"
-                time_est = format_time_estimate(g.count)
+                time_est = format_time_estimate(_rec_count)
                 console.print(
                     f"    [yellow]→ {action.label}[/yellow]  "
                     f"{tilde}{savings_str}  [dim]takes {time_est}[/dim]"
@@ -607,8 +692,6 @@ def triage(
 
     client = _get_client()
     account_email = _get_account_email(client)
-    ai = _get_ai()
-    detector = AvoidanceDetector(client, account_email, ai)
 
     with console.status("Fetching inbox..."):
         ids = client.list_message_ids(query="in:inbox is:unread", max_results=limit)
@@ -617,9 +700,38 @@ def triage(
             return
         messages = client.get_messages_batch(ids)
 
-    _print_ai_data_notice(f"{len(messages)} email subjects + snippets (≤300 chars each)")
-    with console.status(f"Classifying {len(messages)} messages with AI..."):
-        classified = ai.classify_emails(messages)
+    # Try Anthropic first; fall back to local LLM when key is absent or invalid.
+    # Use AIEngine directly (not _get_ai()) so a missing key raises ValueError
+    # instead of silently returning MockAIEngine.
+    classified = None
+    try:
+        import anthropic
+        from mailtrim.core.ai_engine import AIEngine
+
+        ai = AIEngine()  # raises ValueError if ANTHROPIC_API_KEY is unset
+        _print_ai_data_notice(f"{len(messages)} email subjects + snippets (≤300 chars each)")
+        with console.status(f"Classifying {len(messages)} messages with Anthropic AI..."):
+            classified = ai.classify_emails(messages)
+    except (ValueError, anthropic.AuthenticationError, anthropic.RateLimitError,
+            anthropic.APIStatusError, anthropic.APIConnectionError) as exc:
+        # ValueError              → ANTHROPIC_API_KEY not set
+        # AuthenticationError     → key present but invalid
+        # RateLimitError          → quota exceeded, fall back gracefully
+        # APIStatusError          → server-side error (5xx)
+        # APIConnectionError      → network unreachable
+        reason = "no API key set" if isinstance(exc, ValueError) else str(exc)
+        console.print(
+            f"[yellow]Anthropic unavailable ({reason}) — falling back to local AI "
+            f"(localhost:8080).[/yellow]"
+        )
+        from mailtrim.core.llm import classify_for_triage
+        from mailtrim.core.mock_ai import MockAIEngine
+
+        with console.status(f"Classifying {len(messages)} messages with local AI..."):
+            classified = classify_for_triage(messages)
+        ai = MockAIEngine()  # avoidance detector only calls record_view here
+
+    detector = AvoidanceDetector(client, account_email, ai)
 
     # Record views for avoidance tracking
     for msg in messages:
@@ -1019,6 +1131,8 @@ def unsubscribe(
 
     messages: list = []
     if sender:
+        from mailtrim.core.validation import validate_sender_email
+        sender = validate_sender_email(sender)
         with console.status(f"Finding emails from {sender}..."):
             ids = client.list_message_ids(query=f"from:{sender}", max_results=1)
             if ids:
@@ -1241,7 +1355,9 @@ def _print_cleanup_complete(
         body = (
             f"Moved [bold]{email_count:,} emails[/bold] to Trash  ·  "
             f"freed [bold green]~{freed_mb} MB[/bold green]  ·  took [bold]{elapsed_seconds}s[/bold]\n"
-            f"Senders: [dim]{names_str}[/dim]\n" + undo_hint
+            f"Senders: [dim]{names_str}[/dim]\n"
+            f"[dim]Gmail Trash shows threads, not messages — visible count there will be lower.[/dim]"
+            + undo_hint
         )
         border = "green"
         title = "🎉  Cleanup Complete"
@@ -1308,6 +1424,11 @@ def purge(
         "--scope",
         help="Mail scope to scan: 'inbox' (default) or 'anywhere' (includes archived, sent, all mail).",
     ),
+    use_ai: bool = typer.Option(
+        False,
+        "--ai",
+        help="Adjust confidence scores with local AI signal (requires llama.cpp at localhost:8080).",
+    ),
 ):
     """
     Show top email offenders and bulk-delete the ones you choose.
@@ -1327,12 +1448,19 @@ def purge(
     """
     import time as _time
 
-    from mailtrim.core.sender_stats import fetch_sender_groups
+    from mailtrim.core.sender_stats import compute_confidence_score, fetch_sender_groups
     from mailtrim.core.storage import UndoLogRepo, get_session
     from mailtrim.core.unsubscribe import UnsubscribeEngine
+    from mailtrim.core.validation import validate_domain, validate_older_than
 
     client = _get_client()
     account_email = _get_account_email(client)
+
+    # Validate user-supplied values before embedding them in Gmail queries.
+    if domain:
+        domain = validate_domain(domain)
+    if older_than is not None:
+        older_than = validate_older_than(older_than)
 
     # --scope prepends a scope filter to the query unless --query is explicitly set
     if scope == "anywhere" and query == "category:promotions OR label:newsletters":
@@ -1340,11 +1468,13 @@ def purge(
     elif scope == "anywhere":
         query = f"in:anywhere -in:trash -in:spam {query}"
 
-    # --domain builds a targeted query and routes to non-interactive mode
+    # --domain builds a targeted query and routes to non-interactive mode.
+    # Scope filter is always applied so the count matches what stats showed.
     if domain:
-        effective_query = f"from:{domain}"
         if scope == "anywhere":
             effective_query = f"in:anywhere -in:trash -in:spam from:{domain}"
+        else:
+            effective_query = f"in:inbox from:{domain}"
         if older_than:
             effective_query += f" older_than:{older_than}d"
         query = effective_query
@@ -1469,6 +1599,28 @@ def purge(
             f"\n[bold]Domain target:[/bold] [cyan]{domain}[/cyan]  "
             f"[dim]{total_msgs} emails · {total_mb} MB{keep_note}[/dim]"
         )
+
+        # Show a compact per-sender breakdown so the user sees exactly which
+        # addresses (including subdomains) will be affected before confirming.
+        # Gmail's from: query is a suffix match, so mail.domain.com is included.
+        unique_domains = sorted({g.domain for g in groups})
+        if len(unique_domains) > 1:
+            console.print(
+                f"[dim]  Includes subdomains: {', '.join(unique_domains)}[/dim]"
+            )
+        for g in sorted(groups, key=lambda x: x.count, reverse=True)[:10]:
+            size_str = (
+                f"{g.total_size_mb} MB" if g.total_size_mb >= 0.1
+                else f"{g.total_size_bytes // 1024} KB"
+            )
+            console.print(
+                f"  [dim]{g.sender_email}[/dim]  "
+                f"[red]{g.count}[/red] emails · {size_str}"
+            )
+        if len(groups) > 10:
+            console.print(f"  [dim]… and {len(groups) - 10} more sender(s)[/dim]")
+        console.print()
+
         selected = groups
         sel_msgs = total_msgs
         sel_mb = total_mb
@@ -1504,6 +1656,34 @@ def purge(
         return
 
     # ── Step 2: render offender table ────────────────────────────────────────
+
+    # Optional local-AI enrichment — only for senders where AI adds signal.
+    purge_ai_insights: dict[str, dict] = {}
+    if use_ai:
+        from mailtrim.core.llm import (
+            CATEGORY_ICON,
+            analyze_batch,
+            confidence_delta,
+            should_analyze,
+        )
+
+        eligible_groups = [
+            g for g in groups
+            if should_analyze(compute_confidence_score(g), g.count, g.sender_email)
+        ]
+        if eligible_groups:
+            with console.status("[dim][AI] Analyzing senders via local model…[/dim]"):
+                texts = ["\n".join(g.sample_subjects) for g in eligible_groups]
+                keys = [g.sender_email for g in eligible_groups]
+                ai_results = analyze_batch(texts, cache_keys=keys)
+            purge_ai_insights = {
+                g.sender_email: r for g, r in zip(eligible_groups, ai_results)
+            }
+
+        if purge_ai_insights:
+            from mailtrim.core.llm import apply_impact_nudge
+            apply_impact_nudge(groups, purge_ai_insights)
+
     console.print()
     table = Table(
         title=f"Top Email Offenders  [dim]({total_msgs} emails · {total_mb} MB)[/dim]",
@@ -1527,6 +1707,8 @@ def purge(
     table.add_column(date_header, width=14)
     table.add_column("Sample subject", min_width=30)
     table.add_column("Unsub?", width=7)
+    if use_ai:
+        table.add_column("AI", width=12)
 
     for i, g in enumerate(groups, 1):
         name = g.display_name[:30]
@@ -1546,7 +1728,28 @@ def purge(
 
         subject = g.sample_subjects[0][:55] if g.sample_subjects else "—"
         unsub = "[green]yes[/green]" if g.has_unsubscribe else "[dim]no[/dim]"
-        table.add_row(str(i), name, str(g.count), size_str, date_str, subject, unsub)
+
+        if use_ai:
+            ai = purge_ai_insights.get(g.sender_email, {})
+            if ai:
+                from mailtrim.core.llm import CATEGORY_ICON as _ICON
+
+                cat = ai.get("category", "")
+                action = ai.get("action", "")
+                rule_conf = compute_confidence_score(g)
+                delta = confidence_delta(ai)
+                adj_conf = max(0, min(100, rule_conf + delta))
+                sign = "+" if delta > 0 else ""
+                delta_str = f"{sign}{delta}%" if delta != 0 else ""
+                ai_cell = (
+                    f"{_ICON.get(cat, '')} {cat} → {action}\n"
+                    f"[dim]{rule_conf}→{adj_conf}% {delta_str}[/dim]"
+                )
+            else:
+                ai_cell = "[dim]—[/dim]"
+            table.add_row(str(i), name, str(g.count), size_str, date_str, subject, unsub, ai_cell)
+        else:
+            table.add_row(str(i), name, str(g.count), size_str, date_str, subject, unsub)
 
     console.print(table)
 

--- a/mailtrim/config.py
+++ b/mailtrim/config.py
@@ -54,6 +54,9 @@ def get_settings() -> Settings:
     global _settings
     if _settings is None:
         DATA_DIR.mkdir(parents=True, exist_ok=True)
+        # Restrict the data directory so other local users cannot browse it.
+        # Credentials and tokens stored here are sensitive.
+        DATA_DIR.chmod(0o700)
         UNDO_LOG_DIR.mkdir(parents=True, exist_ok=True)
         _settings = Settings()
     return _settings

--- a/mailtrim/core/ai/__init__.py
+++ b/mailtrim/core/ai/__init__.py
@@ -1,0 +1,1 @@
+"""Local AI backend abstraction — llama.cpp, Ollama, and future backends."""

--- a/mailtrim/core/ai/client.py
+++ b/mailtrim/core/ai/client.py
@@ -1,0 +1,169 @@
+"""Local AI backend abstraction — llama.cpp and Ollama.
+
+Design:
+  - AIClient.generate(prompt) → raw string from model
+  - Callers (llm.py) handle parsing, caching, and confidence logic unchanged
+  - Both clients fail silently on network errors — returning "" signals no AI signal
+  - No new dependencies: urllib only
+
+Usage:
+    client = get_ai_client(backend="ollama", url="http://localhost:11434", model="phi3")
+    raw = client.generate(prompt)   # "" on any failure
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 2  # seconds — must not slow down CLI noticeably on CPU-only machines
+
+
+# ── Base class ────────────────────────────────────────────────────────────────
+
+
+class AIClient:
+    """
+    Abstract local AI backend.
+
+    Subclasses implement _post(prompt) → raw response string.
+    generate() wraps _post with timeout enforcement and silent failure.
+    """
+
+    def generate(self, prompt: str) -> str:
+        """
+        Run inference and return the model's raw text output.
+
+        Returns "" on any failure (network error, timeout, parse error).
+        Callers must treat "" as "no AI signal" and fall back to rule-based logic.
+        """
+        try:
+            return self._post(prompt[:600])  # hard truncation before sending
+        except urllib.error.URLError as exc:
+            logger.debug("%s unavailable (URLError): %s", self.__class__.__name__, exc)
+        except TimeoutError as exc:
+            logger.debug("%s timeout: %s", self.__class__.__name__, exc)
+        except json.JSONDecodeError as exc:
+            logger.warning("%s returned invalid JSON: %s", self.__class__.__name__, exc)
+        except Exception as exc:
+            logger.debug(
+                "%s request failed (%s): %s", self.__class__.__name__, type(exc).__name__, exc
+            )
+        return ""
+
+    def _post(self, prompt: str) -> str:
+        raise NotImplementedError
+
+    def _http_post(self, url: str, payload: dict) -> dict:
+        """Shared HTTP POST helper — returns parsed JSON response dict."""
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:  # nosec B310 — localhost only
+            return json.loads(resp.read().decode("utf-8"))
+
+
+# ── llama.cpp backend ─────────────────────────────────────────────────────────
+
+
+class LlamaCppClient(AIClient):
+    """
+    Client for llama.cpp server (github.com/ggerganov/llama.cpp).
+
+    Default endpoint: http://localhost:8080/completion
+    The server must be running with a GBNF grammar to constrain output format.
+    """
+
+    # GBNF grammar constrains the model to only emit valid tokens.
+    # This makes the S/C/A parser in llm.py trivial and eliminates hallucinations.
+    _GRAMMAR = (
+        'root ::= "S:" summary "\\nC:" category "\\nA:" action\n'
+        "summary ::= [^\\n]+\n"
+        'category ::= "important" | "promo" | "update" | "spam"\n'
+        'action ::= "keep" | "archive" | "delete"'
+    )
+
+    def __init__(self, url: str = "http://localhost:8080") -> None:
+        self._endpoint = url.rstrip("/") + "/completion"
+
+    def _post(self, prompt: str) -> str:
+        payload = {
+            "prompt": prompt,
+            "n_predict": 60,
+            "temperature": 0.1,
+            "grammar": self._GRAMMAR,
+            "stop": ["</s>", "<|user|>", "<|system|>"],
+        }
+        data = self._http_post(self._endpoint, payload)
+        return data.get("content", "").strip()
+
+
+# ── Ollama backend ────────────────────────────────────────────────────────────
+
+
+class OllamaClient(AIClient):
+    """
+    Client for Ollama (ollama.ai).
+
+    Default endpoint: http://localhost:11434/api/generate
+    Default model:    phi3  (small, fast on CPU; user-configurable)
+
+    Ollama's response format:
+        {"response": "S:...\nC:...\nA:..."}
+    """
+
+    def __init__(
+        self,
+        url: str = "http://localhost:11434",
+        model: str = "phi3",
+    ) -> None:
+        self._endpoint = url.rstrip("/") + "/api/generate"
+        self._model = model
+
+    def _post(self, prompt: str) -> str:
+        payload = {
+            "model": self._model,
+            "prompt": prompt,
+            "stream": False,
+        }
+        data = self._http_post(self._endpoint, payload)
+        return data.get("response", "").strip()
+
+
+# ── Factory ───────────────────────────────────────────────────────────────────
+
+
+def get_ai_client(
+    backend: str = "llama",
+    url: str = "",
+    model: str = "phi3",
+) -> AIClient:
+    """
+    Construct and return the appropriate AIClient.
+
+    Args:
+        backend: "llama" (llama.cpp) or "ollama"
+        url:     Override the default server URL
+        model:   Model name — only used by Ollama
+
+    The returned client fails silently on all network errors, so the pipeline
+    degrades gracefully when no local AI server is running.
+    """
+    if backend == "ollama":
+        return OllamaClient(
+            url=url or "http://localhost:11434",
+            model=model,
+        )
+
+    if backend == "llama":
+        return LlamaCppClient(url=url or "http://localhost:8080")
+
+    raise ValueError(f"Unknown AI backend '{backend}'. Valid options: llama, ollama")

--- a/mailtrim/core/ai/client.py
+++ b/mailtrim/core/ai/client.py
@@ -41,8 +41,12 @@ class AIClient:
         Returns "" on any failure (network error, timeout, parse error).
         Callers must treat "" as "no AI signal" and fall back to rule-based logic.
         """
+        truncated = prompt[:600]
+        logger.debug("→ prompt sent (%d chars): %s", len(truncated), truncated[:120])
         try:
-            return self._post(prompt[:600])  # hard truncation before sending
+            result = self._post(truncated)
+            logger.debug("← raw response: %r", result)
+            return result
         except urllib.error.URLError as exc:
             logger.debug("%s unavailable (URLError): %s", self.__class__.__name__, exc)
         except TimeoutError as exc:
@@ -53,6 +57,7 @@ class AIClient:
             logger.debug(
                 "%s request failed (%s): %s", self.__class__.__name__, type(exc).__name__, exc
             )
+        logger.debug("← no response (failure)")
         return ""
 
     def _post(self, prompt: str) -> str:

--- a/mailtrim/core/ai_engine.py
+++ b/mailtrim/core/ai_engine.py
@@ -73,7 +73,8 @@ class AIEngine:
         key = api_key or settings.anthropic_api_key
         if not key:
             raise ValueError(
-                "ANTHROPIC_API_KEY is not set. Run: export ANTHROPIC_API_KEY=sk-ant-..."
+                "ANTHROPIC_API_KEY is not set. "
+                "Set it as an environment variable before running this command."
             )
         self._client = anthropic.Anthropic(api_key=key)
         self._model = settings.ai_model

--- a/mailtrim/core/diagnostics.py
+++ b/mailtrim/core/diagnostics.py
@@ -1,0 +1,274 @@
+"""
+Diagnostic checks for mailtrim doctor command.
+
+Each check returns a CheckResult.  All checks are independent — a failure in
+one does not prevent the others from running.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    message: str
+    fix: str = ""  # one-line fix hint shown on failure
+    optional: bool = False  # optional checks show ⚠ instead of ✗
+
+
+# ── Individual checks ─────────────────────────────────────────────────────────
+
+
+def check_token_exists() -> CheckResult:
+    from mailtrim.config import TOKEN_PATH
+
+    if TOKEN_PATH.exists():
+        return CheckResult("Auth token file", ok=True, message="Token file present")
+    return CheckResult(
+        "Auth token file",
+        ok=False,
+        message="Token file not found",
+        fix="mailtrim auth",
+    )
+
+
+def check_token_valid() -> CheckResult:
+    from mailtrim.config import TOKEN_PATH
+
+    if not TOKEN_PATH.exists():
+        return CheckResult(
+            "Auth token valid",
+            ok=False,
+            message="No token to validate",
+            fix="mailtrim auth",
+        )
+    try:
+        from google.oauth2.credentials import Credentials
+
+        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH))
+        if creds.expired and not creds.refresh_token:
+            return CheckResult(
+                "Auth token valid",
+                ok=False,
+                message="Token expired, no refresh token",
+                fix="mailtrim auth",
+            )
+        return CheckResult("Auth token valid", ok=True, message="Token looks valid")
+    except Exception as exc:
+        return CheckResult(
+            "Auth token valid",
+            ok=False,
+            message=f"Token unreadable: {exc}",
+            fix="mailtrim auth",
+        )
+
+
+def check_gmail_connection() -> CheckResult:
+    try:
+        from mailtrim.core.gmail_client import GmailClient, authenticate
+
+        creds = authenticate()
+        client = GmailClient(creds)
+        profile = client.get_profile()
+        email = profile.get("emailAddress", "unknown")
+        return CheckResult("Gmail connection", ok=True, message=f"Connected as {email}")
+    except FileNotFoundError:
+        return CheckResult(
+            "Gmail connection",
+            ok=False,
+            message="OAuth credentials file missing",
+            fix="Download credentials.json from Google Cloud Console — see README",
+        )
+    except Exception as exc:
+        _msg = str(exc)
+        if "invalid_grant" in _msg or "401" in _msg:
+            return CheckResult(
+                "Gmail connection",
+                ok=False,
+                message="Gmail session expired",
+                fix="mailtrim auth",
+            )
+        if "timed out" in _msg.lower() or "connection" in _msg.lower():
+            return CheckResult(
+                "Gmail connection",
+                ok=False,
+                message="Could not reach Gmail — check internet connection",
+                fix="Check network, then retry",
+            )
+        return CheckResult(
+            "Gmail connection",
+            ok=False,
+            message=f"Connection failed: {_msg[:80]}",
+            fix="mailtrim auth",
+        )
+
+
+def check_trash_access() -> CheckResult:
+    try:
+        from mailtrim.core.gmail_client import GmailClient, authenticate
+
+        creds = authenticate()
+        client = GmailClient(creds)
+        # List 1 trashed message — proves we can query Trash without side effects
+        client.list_message_ids(query="in:trash", max_results=1)
+        return CheckResult("Trash access", ok=True, message="Trash label readable")
+    except Exception as exc:
+        return CheckResult(
+            "Trash access",
+            ok=False,
+            message=f"Cannot read Trash: {str(exc)[:80]}",
+            fix="Check Gmail API scopes — may need to re-run mailtrim auth",
+        )
+
+
+def check_data_dir() -> CheckResult:
+    from mailtrim.config import DATA_DIR
+
+    try:
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        test_file = DATA_DIR / ".doctor_check"
+        test_file.write_text("ok")
+        test_file.unlink()
+        return CheckResult("Data directory", ok=True, message=f"Writable at {DATA_DIR}")
+    except OSError as exc:
+        return CheckResult(
+            "Data directory",
+            ok=False,
+            message=f"Cannot write to {DATA_DIR}: {exc}",
+            fix=f"Check permissions on {DATA_DIR.parent}",
+        )
+
+
+def check_undo_storage() -> CheckResult:
+    try:
+        from mailtrim.core.storage import UndoLogRepo, get_session
+
+        session = get_session()
+        repo = UndoLogRepo(session)
+        repo.list_recent(limit=1)
+        return CheckResult("Undo storage", ok=True, message="Database readable and writable")
+    except Exception as exc:
+        return CheckResult(
+            "Undo storage",
+            ok=False,
+            message=f"Database error: {str(exc)[:80]}",
+            fix="Delete ~/.mailtrim/mailtrim.db and retry (undo history will be lost)",
+        )
+
+
+def check_config() -> CheckResult:
+    try:
+        from mailtrim.config import get_settings
+
+        settings = get_settings()
+        _ = settings.undo_window_days  # access any field
+        return CheckResult("Config", ok=True, message="Configuration loaded successfully")
+    except Exception as exc:
+        return CheckResult(
+            "Config",
+            ok=False,
+            message=f"Config error: {str(exc)[:80]}",
+            fix="Check ~/.mailtrim/.env for syntax errors",
+        )
+
+
+def check_ai_endpoint(url: str = "http://localhost:8080") -> CheckResult:
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(f"{url}/health", method="GET")
+        with urllib.request.urlopen(req, timeout=2):  # nosec B310 — localhost health check only
+            pass
+        return CheckResult(
+            "Local AI endpoint",
+            ok=True,
+            message=f"llama.cpp reachable at {url}",
+            optional=True,
+        )
+    except Exception:
+        return CheckResult(
+            "Local AI endpoint",
+            ok=False,
+            message=f"Not reachable at {url} (optional — only needed for --ai flag)",
+            optional=True,
+        )
+
+
+def check_dependencies() -> CheckResult:
+    missing = []
+    packages = [
+        ("google.auth", "google-auth"),
+        ("googleapiclient", "google-api-python-client"),
+        ("rich", "rich"),
+        ("typer", "typer"),
+        ("sqlalchemy", "sqlalchemy"),
+        ("pydantic_settings", "pydantic-settings"),
+    ]
+    for module, pkg in packages:
+        try:
+            __import__(module)
+        except ImportError:
+            missing.append(pkg)
+
+    if missing:
+        return CheckResult(
+            "Required packages",
+            ok=False,
+            message=f"Missing: {', '.join(missing)}",
+            fix="pip install mailtrim",
+        )
+    return CheckResult("Required packages", ok=True, message="All required packages present")
+
+
+# ── Run all checks ────────────────────────────────────────────────────────────
+
+# Ordered list of checks. Gmail-dependent ones come after token/dep checks.
+_CHECKS: list[Callable[[], CheckResult]] = [
+    check_dependencies,
+    check_config,
+    check_data_dir,
+    check_undo_storage,
+    check_token_exists,
+    check_token_valid,
+    check_gmail_connection,
+    check_trash_access,
+]
+
+_OPTIONAL_CHECKS: list[Callable[[], CheckResult]] = [
+    check_ai_endpoint,
+]
+
+
+def run_all(include_optional: bool = True) -> list[CheckResult]:
+    """Run all checks and return results in order."""
+    results = []
+    for fn in _CHECKS:
+        try:
+            results.append(fn())
+        except Exception as exc:
+            results.append(
+                CheckResult(
+                    fn.__name__,
+                    ok=False,
+                    message=f"Check crashed: {exc}",
+                    fix="Please report this at github.com/sadhgurutech/mailtrim/issues",
+                )
+            )
+    if include_optional:
+        for fn in _OPTIONAL_CHECKS:
+            try:
+                results.append(fn())
+            except Exception as exc:
+                results.append(
+                    CheckResult(
+                        fn.__name__,
+                        ok=False,
+                        message=f"Check crashed: {exc}",
+                        optional=True,
+                    )
+                )
+    return results

--- a/mailtrim/core/errors.py
+++ b/mailtrim/core/errors.py
@@ -1,0 +1,136 @@
+"""
+Human-readable error translation for common failure modes.
+
+Usage:
+    from mailtrim.core.errors import friendly_error
+    try:
+        ...
+    except Exception as exc:
+        msg, fix = friendly_error(exc)
+        console.print(f"[red]{msg}[/red]")
+        if fix:
+            console.print(f"  [dim]Fix: {fix}[/dim]")
+        raise typer.Exit(1)
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def friendly_error(exc: BaseException) -> tuple[str, str]:
+    """
+    Map an exception to a (human message, fix hint) tuple.
+
+    Returns plain strings — caller decides how to display them.
+    The message is always set; fix may be empty.
+    """
+    msg = str(exc)
+    msg_lower = msg.lower()
+
+    # ── Auth / OAuth ──────────────────────────────────────────────────────────
+    if "invalid_grant" in msg_lower or (
+        "401" in msg and ("gmail" in msg_lower or "google" in msg_lower)
+    ):
+        return (
+            "Your Gmail connection expired.",
+            "Run: mailtrim auth",
+        )
+
+    if "credentials" in msg_lower and "not found" in msg_lower:
+        return (
+            "OAuth credentials file not found.",
+            "Download credentials.json from Google Cloud Console — see README for setup steps.",
+        )
+
+    if "token" in msg_lower and ("expired" in msg_lower or "invalid" in msg_lower):
+        return (
+            "Gmail token is no longer valid.",
+            "Run: mailtrim auth",
+        )
+
+    if "access_denied" in msg_lower or "403" in msg:
+        return (
+            "Gmail access denied — insufficient permissions.",
+            "Re-run: mailtrim auth  (grant all requested scopes)",
+        )
+
+    # ── Network ───────────────────────────────────────────────────────────────
+    if any(
+        kw in msg_lower for kw in ("timed out", "timeout", "connection refused", "connection reset")
+    ):
+        return (
+            "Could not reach Gmail — check your internet connection and try again.",
+            "",
+        )
+
+    if "name or service not known" in msg_lower or "nodename nor servname" in msg_lower:
+        return (
+            "DNS lookup failed — no internet connection or Gmail is unreachable.",
+            "Check your network, then retry.",
+        )
+
+    if "ssl" in msg_lower and ("cert" in msg_lower or "handshake" in msg_lower):
+        return (
+            "SSL/TLS error connecting to Gmail.",
+            "Check that your system certificates are up to date.",
+        )
+
+    # ── File system ───────────────────────────────────────────────────────────
+    if isinstance(exc, PermissionError) or "permission denied" in msg_lower:
+        path_match = re.search(r"'([^']+)'", msg)
+        path_hint = f" ({path_match.group(1)})" if path_match else ""
+        return (
+            f"mailtrim cannot write to your local config files{path_hint}.",
+            "Check folder permissions on ~/.mailtrim/",
+        )
+
+    if isinstance(exc, FileNotFoundError):
+        return (
+            f"Required file not found: {msg[:100]}",
+            "Check the path or run: mailtrim auth",
+        )
+
+    if isinstance(exc, OSError) and "no space left" in msg_lower:
+        return (
+            "No disk space left — mailtrim cannot save state.",
+            "Free up disk space, then retry.",
+        )
+
+    # ── Gmail API ────────────────────────────────────────────────────────────
+    if "quotaExceeded" in msg or "rateLimitExceeded" in msg or "429" in msg:
+        return (
+            "Gmail API rate limit hit — you've sent too many requests.",
+            "Wait 60 seconds and try again.",
+        )
+
+    if "HttpError 500" in msg or "HttpError 502" in msg or "HttpError 503" in msg:
+        return (
+            "Gmail API is temporarily unavailable (server error).",
+            "Wait a few minutes and retry.",
+        )
+
+    if "userRateLimitExceeded" in msg:
+        return (
+            "You've hit Gmail's per-user rate limit.",
+            "Wait a minute, then retry with a smaller --max-scan value.",
+        )
+
+    # ── Database ─────────────────────────────────────────────────────────────
+    if "database" in msg_lower or "sqlite" in msg_lower or "no such table" in msg_lower:
+        return (
+            "Local database error — undo history may be unavailable.",
+            "If this persists, delete ~/.mailtrim/mailtrim.db and retry.",
+        )
+
+    if "disk image is malformed" in msg_lower or "database disk image" in msg_lower:
+        return (
+            "Local database is corrupted.",
+            "Delete ~/.mailtrim/mailtrim.db — your Gmail is unaffected, but undo history will be lost.",
+        )
+
+    # ── Fallback ─────────────────────────────────────────────────────────────
+    return (
+        f"Unexpected error: {msg[:120]}",
+        "If this persists, report it at github.com/sadhgurutech/mailtrim/issues",
+    )

--- a/mailtrim/core/gmail_client.py
+++ b/mailtrim/core/gmail_client.py
@@ -151,9 +151,9 @@ def authenticate(
     if token_path.exists():
         try:
             creds = Credentials.from_authorized_user_file(str(token_path), scopes)
-        except Exception:
-            # Corrupted token — delete and re-authenticate
-            logger.warning("Token file is corrupted, re-authenticating.")
+        except Exception as exc:
+            # Corrupted or unreadable token — delete and re-authenticate.
+            logger.warning("Token file is corrupted (%s), re-authenticating.", exc)
             token_path.unlink(missing_ok=True)
             creds = None
 
@@ -161,8 +161,8 @@ def authenticate(
         if creds and creds.expired and creds.refresh_token:
             try:
                 creds.refresh(Request())
-            except Exception:
-                logger.warning("Token refresh failed, re-authenticating.")
+            except Exception as exc:
+                logger.warning("Token refresh failed (%s), re-authenticating.", exc)
                 token_path.unlink(missing_ok=True)
                 creds = None
 
@@ -172,6 +172,15 @@ def authenticate(
                     f"OAuth credentials file not found at {credentials_path}.\n"
                     "Download it from Google Cloud Console → APIs & Services → Credentials.\n"
                     "See README.md for step-by-step setup."
+                )
+            # Restrict the credentials file too — it contains the OAuth client secret.
+            # Do this before reading so the secret is protected even on first run.
+            try:
+                credentials_path.chmod(0o600)
+            except OSError:
+                logger.warning(
+                    "Could not set permissions on %s — ensure only you can read it.",
+                    credentials_path,
                 )
             flow = InstalledAppFlow.from_client_secrets_file(str(credentials_path), scopes)
             creds = flow.run_local_server(port=0)

--- a/mailtrim/core/llm.py
+++ b/mailtrim/core/llm.py
@@ -1,0 +1,406 @@
+"""
+Optional local LLM integration — llama.cpp server at http://localhost:8080.
+
+Drop-in enhancement: if the server is unavailable, every call returns {}
+and the caller falls back to rule-based logic unchanged.
+
+Usage:
+    from mailtrim.core.llm import analyze_email, analyze_batch, confidence_delta
+    from mailtrim.core.llm import classify_for_triage  # triage fallback
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from mailtrim.core.ai_engine import ClassifiedEmail
+    from mailtrim.core.gmail_client import Message
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+_ENDPOINT = "http://localhost:8080/completion"
+_TIMEOUT = 30  # seconds — CPU-only llama.cpp needs time to evaluate the prompt
+
+# Prompt uses TinyLlama/llama.cpp chat template so the model generates a
+# completion rather than echoing the instructions back.
+_SYSTEM_PROMPT = (
+    "You are an email classifier. Only output S/C/A lines, nothing else."
+)
+
+# Few-shot examples teach the format without relying on instruction-following.
+_FEW_SHOT = (
+    "<|user|>\n"
+    "From: Bank\nSubject: Security alert\nNew login from unknown device.</s>\n"
+    "<|assistant|>\n"
+    "S:New login detected on account\nC:important\nA:keep</s>\n"
+    "<|user|>\n"
+    "From: Deals\nSubject: 50% off this weekend only\nShop now for huge savings.</s>\n"
+    "<|assistant|>\n"
+    "S:Weekend sale fifty percent discount\nC:promo\nA:delete</s>\n"
+    "<|user|>\n"
+    "From: GitHub\nSubject: Build failed on main\nYour CI run #42 failed.</s>\n"
+    "<|assistant|>\n"
+    "S:CI build failed on main branch\nC:update\nA:archive</s>\n"
+)
+
+_VALID_CATEGORIES = frozenset({"important", "promo", "update", "spam"})
+_VALID_ACTIONS = frozenset({"keep", "archive", "delete"})
+
+# GBNF grammar constrains the model to only emit valid tokens for C and A.
+# This makes the parser trivial and eliminates hallucinated labels entirely.
+_GRAMMAR = (
+    'root ::= "S:" summary "\\nC:" category "\\nA:" action\n'
+    "summary ::= [^\\n]+\n"
+    'category ::= "important" | "promo" | "update" | "spam"\n'
+    'action ::= "keep" | "archive" | "delete"'
+)
+
+# AI signal → confidence delta.  Spam overrides action; capped at ±15.
+_ACTION_DELTA: dict[str, int] = {"delete": 10, "archive": -3, "keep": -10}
+_SPAM_DELTA = 15  # applied instead of action delta when category == "spam"
+_DELTA_CAP = 15
+
+# Per-category display icon — consistent across stats, purge, triage.
+CATEGORY_ICON: dict[str, str] = {
+    "important": "🟢",
+    "promo": "🟠",
+    "update": "🔵",
+    "spam": "🔴",
+}
+
+
+# ── Core function ─────────────────────────────────────────────────────────────
+
+
+def analyze_email(text: str, cache_key: str = "") -> dict:
+    """
+    Analyze email text via the local llama.cpp server.
+
+    Args:
+        text:      Subject + snippet. Auto-truncated to 600 chars.
+        cache_key: Optional sender email / domain for result caching.
+                   Pass "" to skip caching.
+
+    Returns:
+        On success: {"summary": str, "category": str, "action": str}
+        On any failure: {} — caller must treat this as "no AI signal".
+    """
+    if cache_key:
+        cached = get_cached(cache_key)
+        if cached:
+            return cached
+
+    content = text.strip()[:600]
+    prompt = (
+        f"<|system|>\n{_SYSTEM_PROMPT}</s>\n"
+        f"{_FEW_SHOT}"
+        f"<|user|>\n{content}</s>\n"
+        f"<|assistant|>\n"
+    )
+
+    payload = json.dumps({
+        "prompt": prompt,
+        "n_predict": 60,
+        "temperature": 0.1,
+        "grammar": _GRAMMAR,
+        "stop": ["</s>", "<|user|>", "<|system|>"],
+    }).encode("utf-8")
+
+    try:
+        req = urllib.request.Request(
+            _ENDPOINT,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        response_text = data.get("content", "").strip()
+    except urllib.error.URLError as exc:
+        # Server offline or unreachable — expected when llama.cpp is not running.
+        logger.debug("Local LLM unavailable (URLError): %s", exc)
+        return {}
+    except json.JSONDecodeError as exc:
+        # Unexpected: server returned non-JSON.  Log at WARNING so the operator sees it.
+        logger.warning("Local LLM returned invalid JSON: %s", exc)
+        return {}
+    except Exception as exc:
+        # Catch-all for timeouts, SSL errors, etc. — silenced but logged.
+        logger.debug("Local LLM request failed (%s): %s", type(exc).__name__, exc)
+        return {}
+
+    result = _parse_response(response_text)
+    if cache_key and result:
+        set_cached(cache_key, result)
+    return result
+
+
+def analyze_batch(
+    texts: list[str],
+    cache_keys: list[str] | None = None,
+    max_workers: int = 4,
+) -> list[dict]:
+    """
+    Analyze multiple email texts in parallel (bounded thread pool).
+
+    Args:
+        texts:       Email content strings (one per sender).
+        cache_keys:  Optional per-entry keys for result caching (same length as texts).
+        max_workers: Thread concurrency cap.
+
+    Results are returned in the same order as ``texts``.
+    Individual failures produce {} entries, not exceptions.
+    """
+    keys = cache_keys or [""] * len(texts)
+    results: list[dict] = [{}] * len(texts)
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {
+            pool.submit(analyze_email, t, k): i for i, (t, k) in enumerate(zip(texts, keys))
+        }
+        for fut in as_completed(futures):
+            idx = futures[fut]
+            try:
+                results[idx] = fut.result()
+            except Exception as exc:
+                logger.debug("Batch LLM item %d failed (%s): %s", idx, type(exc).__name__, exc)
+                results[idx] = {}
+    return results
+
+
+# ── In-memory cache (keyed by sender email or domain) ────────────────────────
+
+_cache: dict[str, dict] = {}
+
+
+def get_cached(key: str) -> dict:
+    """Return a cached AI result for *key*, or {} if not cached."""
+    return _cache.get(key, {})
+
+
+def set_cached(key: str, result: dict) -> None:
+    """Store an AI result in the process-level cache."""
+    if result:
+        _cache[key] = result
+
+
+# ── Display helpers ───────────────────────────────────────────────────────────
+
+# Words that carry no signal when used as the entire "reason".
+_FILLER = frozenset(
+    {"the", "a", "an", "is", "it", "of", "in", "on", "at", "to", "for",
+     "and", "or", "with", "your", "you", "we", "our", "this", "that"}
+)
+
+
+def _short_summary(summary: str, max_words: int = 6) -> str:
+    """
+    Trim a raw summary to ≤max_words meaningful words.
+
+    Strips filler-only prefixes and truncates cleanly.
+    """
+    words = summary.strip().split()
+    # Drop leading filler words
+    start = 0
+    for w in words:
+        if w.lower().rstrip(".,!?") in _FILLER:
+            start += 1
+        else:
+            break
+    meaningful = words[start:] or words  # never return empty
+    return " ".join(meaningful[:max_words])
+
+
+def format_ai_line(ai: dict) -> str:
+    """
+    Build the inline AI insight line shown under each sender.
+
+    Format:  [AI] 🟠 promo → delete · "weekly sale"
+
+    Placing action immediately after category makes the intent obvious even
+    when category and action appear to contradict each other (e.g. promo→keep).
+    The quoted summary provides the reason without cluttering the main line.
+    """
+    cat = ai.get("category", "")
+    action = ai.get("action", "")
+    icon = CATEGORY_ICON.get(cat, "")
+    short = _short_summary(ai.get("summary", ""))
+    return f'[AI] {icon} {cat} → {action} · "{short}"'
+
+
+# ── Confidence integration ────────────────────────────────────────────────────
+
+
+def confidence_delta(ai_result: dict) -> int:
+    """
+    Map AI signal to a confidence score adjustment, capped at ±_DELTA_CAP.
+
+    spam category overrides the action-based delta (strongest signal).
+    Positive → more confident it is bulk/deletable.
+    Negative → AI says keep or archive → reduce confidence.
+    """
+    if not ai_result:
+        return 0
+    if ai_result.get("category") == "spam":
+        return _SPAM_DELTA
+    delta = _ACTION_DELTA.get(ai_result.get("action", ""), 0)
+    return max(-_DELTA_CAP, min(_DELTA_CAP, delta))
+
+
+# ── Impact score nudge ───────────────────────────────────────────────────────
+
+
+def apply_impact_nudge(groups: list, ai_insights: dict[str, dict]) -> None:
+    """
+    Adjust SenderGroup.impact_score in-place based on AI category signal.
+
+    promo  → +5  (more likely to be cleanable clutter)
+    important → -10 (reduce urgency to delete)
+
+    Changes are small and bounded to [0, 100] so the base formula dominates.
+    Called only when --ai is active.
+    """
+    _nudge = {"promo": 5, "important": -10}
+    for g in groups:
+        ai = ai_insights.get(g.sender_email, {})
+        delta = _nudge.get(ai.get("category", ""), 0)
+        if delta:
+            g.impact_score = max(0, min(100, g.impact_score + delta))
+
+
+# ── Eligibility filter ────────────────────────────────────────────────────────
+
+
+def should_analyze(rule_confidence: int, email_count: int, sender_email: str) -> bool:
+    """
+    Return True only for senders where AI adds value.
+
+    Skip AI when:
+    - Rule confidence is already high (≥70) — AI can't meaningfully improve a clear case.
+    - Very high email count (>50) — frequency alone is decisive; AI is redundant.
+
+    Run AI when:
+    - Low confidence (<60) — AI may resolve ambiguity.
+    - Small send volume (<20) — fewer signals for rules, AI adds more.
+    - Sender looks personal (no @domain.tld pattern) — harder to score by rules.
+    """
+    if rule_confidence >= 70:
+        return False
+    if email_count > 50 and rule_confidence >= 60:
+        return False
+    return True
+
+
+# ── Internal ──────────────────────────────────────────────────────────────────
+
+
+def _parse_response(text: str) -> dict:
+    """
+    Parse the grammar-constrained model output.
+
+    The grammar guarantees the format is exactly:
+        S:<summary>
+        C:<important|promo|update|spam>
+        A:<keep|archive|delete>
+
+    Returns {} only if something unexpected slipped through.
+    """
+    summary: str | None = None
+    category: str | None = None
+    action: str | None = None
+
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("S:") and summary is None:
+            summary = line[2:].strip()
+        elif line.startswith("C:") and category is None:
+            category = line[2:].strip()
+        elif line.startswith("A:") and action is None:
+            action = line[2:].strip()
+
+    if not summary or category not in _VALID_CATEGORIES or action not in _VALID_ACTIONS:
+        return {}
+
+    return {"summary": summary, "category": category, "action": action}
+
+
+# ── Triage adapter ────────────────────────────────────────────────────────────
+
+# Map local LLM categories → triage display categories + metadata defaults.
+# The local model uses a simpler 4-way split; we widen it to match ClassifiedEmail.
+_TRIAGE_MAP: dict[str, tuple[str, str, str, bool]] = {
+    #           category         priority  suggested_action  requires_reply
+    "important": ("action_required", "high",   "reply",          True),
+    "promo":     ("newsletter",      "low",    "unsubscribe",     False),
+    "update":    ("notification",    "low",    "archive",         False),
+    "spam":      ("spam",            "low",    "delete",          False),
+}
+
+# When local LLM says "keep" but category implies deletable, trust the category.
+# "archive" and "delete" are mapped directly.
+_ACTION_OVERRIDE: dict[str, str] = {
+    "archive": "archive",
+    "delete":  "delete",
+}
+
+
+def classify_for_triage(messages: list[Message]) -> list[ClassifiedEmail]:
+    """
+    Classify a list of Gmail messages using the local llama.cpp server.
+
+    Fallback chain per message:
+      1. local LLM (localhost:8080) — best signal
+      2. MockAIEngine               — rule-based heuristics (subject keywords,
+                                      List-Unsubscribe header, etc.)
+
+    The triage table is always fully populated regardless of server availability.
+
+    Returns:
+        list[ClassifiedEmail] in the same order as ``messages``.
+    """
+    from mailtrim.core.ai_engine import ClassifiedEmail
+    from mailtrim.core.mock_ai import MockAIEngine
+
+    mock = MockAIEngine()
+
+    texts = [
+        f"From: {m.sender_name or m.sender_email}\n"
+        f"Subject: {m.headers.subject}\n"
+        f"{m.snippet[:500]}"
+        for m in messages
+    ]
+    raw_results = analyze_batch(texts, max_workers=4)
+
+    classified: list[ClassifiedEmail] = []
+    for msg, result in zip(messages, raw_results):
+        if result:
+            llm_cat = result["category"]
+            llm_action = result["action"]
+            llm_summary = result["summary"]
+
+            triage_cat, priority, default_action, requires_reply = _TRIAGE_MAP[llm_cat]
+            suggested_action = _ACTION_OVERRIDE.get(llm_action, default_action)
+
+            classified.append(
+                ClassifiedEmail(
+                    gmail_id=msg.id,
+                    category=triage_cat,
+                    priority=priority,
+                    explanation=f"[local AI] {llm_summary}",
+                    suggested_action=suggested_action,
+                    requires_reply=requires_reply,
+                    deadline_hint="",
+                )
+            )
+        else:
+            # Local LLM unavailable — fall back to MockAIEngine heuristics.
+            classified.append(mock.classify_emails([msg])[0])
+
+    return classified

--- a/mailtrim/core/llm.py
+++ b/mailtrim/core/llm.py
@@ -277,20 +277,39 @@ def apply_impact_nudge(groups: list, ai_insights: dict[str, dict]) -> None:
 # ── Eligibility filter ────────────────────────────────────────────────────────
 
 
-def should_analyze(rule_confidence: int, email_count: int, sender_email: str) -> bool:
+_SENSITIVE_KEYWORDS: frozenset[str] = frozenset(
+    {"bank", "finance", "financial", "card", "statement", "credit", "loan", "invest"}
+)
+
+
+def should_analyze(
+    rule_confidence: int,
+    email_count: int,
+    sender_email: str,
+    *,
+    is_top_sender: bool = False,
+) -> bool:
     """
     Return True only for senders where AI adds value.
 
+    Always analyze:
+    - Top recommended senders (is_top_sender=True) — AI validates the recommendation.
+    - Senders with bank/finance keywords — high cost of mistaken deletion.
+
     Skip AI when:
-    - Rule confidence is already high (≥70) — AI can't meaningfully improve a clear case.
-    - Very high email count (>50) — frequency alone is decisive; AI is redundant.
+    - Rule confidence is already very high (≥80) and sender is not sensitive.
+    - Very high email count (>50) with moderate-high confidence — frequency is decisive.
 
     Run AI when:
     - Low confidence (<60) — AI may resolve ambiguity.
     - Small send volume (<20) — fewer signals for rules, AI adds more.
-    - Sender looks personal (no @domain.tld pattern) — harder to score by rules.
     """
-    if rule_confidence >= 70:
+    if is_top_sender:
+        return True
+    email_lower = sender_email.lower()
+    if any(kw in email_lower for kw in _SENSITIVE_KEYWORDS):
+        return True
+    if rule_confidence >= 80:
         return False
     if email_count > 50 and rule_confidence >= 60:
         return False
@@ -325,6 +344,12 @@ def _parse_response(text: str) -> dict:
             action = line[2:].strip()
 
     if not summary or category not in _VALID_CATEGORIES or action not in _VALID_ACTIONS:
+        logger.debug(
+            "parse failed: summary=%r category=%r action=%r",
+            summary,
+            category,
+            action,
+        )
         return {}
 
     return {"summary": summary, "category": category, "action": action}

--- a/mailtrim/core/llm.py
+++ b/mailtrim/core/llm.py
@@ -11,12 +11,11 @@ Usage:
 
 from __future__ import annotations
 
-import json
 import logging
-import urllib.error
-import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING
+
+from mailtrim.core.ai.client import AIClient, get_ai_client
 
 logger = logging.getLogger(__name__)
 
@@ -26,14 +25,13 @@ if TYPE_CHECKING:
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
-_ENDPOINT = "http://localhost:8080/completion"
-_TIMEOUT = 30  # seconds — CPU-only llama.cpp needs time to evaluate the prompt
+# Default client — llama.cpp at localhost:8080.
+# Override via analyze_email(ai_client=...) or replace _default_client at startup.
+_default_client: AIClient = get_ai_client(backend="llama")
 
 # Prompt uses TinyLlama/llama.cpp chat template so the model generates a
 # completion rather than echoing the instructions back.
-_SYSTEM_PROMPT = (
-    "You are an email classifier. Only output S/C/A lines, nothing else."
-)
+_SYSTEM_PROMPT = "You are an email classifier. Only output S/C/A lines, nothing else."
 
 # Few-shot examples teach the format without relying on instruction-following.
 _FEW_SHOT = (
@@ -80,14 +78,21 @@ CATEGORY_ICON: dict[str, str] = {
 # ── Core function ─────────────────────────────────────────────────────────────
 
 
-def analyze_email(text: str, cache_key: str = "") -> dict:
+def analyze_email(
+    text: str,
+    cache_key: str = "",
+    ai_client: AIClient | None = None,
+) -> dict:
     """
-    Analyze email text via the local llama.cpp server.
+    Analyze email text via the configured local AI backend.
 
     Args:
         text:      Subject + snippet. Auto-truncated to 600 chars.
         cache_key: Optional sender email / domain for result caching.
                    Pass "" to skip caching.
+        ai_client: Override the module-level default client.
+                   Pass an OllamaClient or LlamaCppClient to switch backends
+                   without changing global state.
 
     Returns:
         On success: {"summary": str, "category": str, "action": str}
@@ -100,41 +105,12 @@ def analyze_email(text: str, cache_key: str = "") -> dict:
 
     content = text.strip()[:600]
     prompt = (
-        f"<|system|>\n{_SYSTEM_PROMPT}</s>\n"
-        f"{_FEW_SHOT}"
-        f"<|user|>\n{content}</s>\n"
-        f"<|assistant|>\n"
+        f"<|system|>\n{_SYSTEM_PROMPT}</s>\n{_FEW_SHOT}<|user|>\n{content}</s>\n<|assistant|>\n"
     )
 
-    payload = json.dumps({
-        "prompt": prompt,
-        "n_predict": 60,
-        "temperature": 0.1,
-        "grammar": _GRAMMAR,
-        "stop": ["</s>", "<|user|>", "<|system|>"],
-    }).encode("utf-8")
-
-    try:
-        req = urllib.request.Request(
-            _ENDPOINT,
-            data=payload,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
-            data = json.loads(resp.read().decode("utf-8"))
-        response_text = data.get("content", "").strip()
-    except urllib.error.URLError as exc:
-        # Server offline or unreachable — expected when llama.cpp is not running.
-        logger.debug("Local LLM unavailable (URLError): %s", exc)
-        return {}
-    except json.JSONDecodeError as exc:
-        # Unexpected: server returned non-JSON.  Log at WARNING so the operator sees it.
-        logger.warning("Local LLM returned invalid JSON: %s", exc)
-        return {}
-    except Exception as exc:
-        # Catch-all for timeouts, SSL errors, etc. — silenced but logged.
-        logger.debug("Local LLM request failed (%s): %s", type(exc).__name__, exc)
+    client = ai_client or _default_client
+    response_text = client.generate(prompt)
+    if not response_text:
         return {}
 
     result = _parse_response(response_text)
@@ -147,6 +123,7 @@ def analyze_batch(
     texts: list[str],
     cache_keys: list[str] | None = None,
     max_workers: int = 4,
+    ai_client: AIClient | None = None,
 ) -> list[dict]:
     """
     Analyze multiple email texts in parallel (bounded thread pool).
@@ -155,6 +132,7 @@ def analyze_batch(
         texts:       Email content strings (one per sender).
         cache_keys:  Optional per-entry keys for result caching (same length as texts).
         max_workers: Thread concurrency cap.
+        ai_client:   Override the module-level default client.
 
     Results are returned in the same order as ``texts``.
     Individual failures produce {} entries, not exceptions.
@@ -163,7 +141,8 @@ def analyze_batch(
     results: list[dict] = [{}] * len(texts)
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         futures = {
-            pool.submit(analyze_email, t, k): i for i, (t, k) in enumerate(zip(texts, keys))
+            pool.submit(analyze_email, t, k, ai_client): i
+            for i, (t, k) in enumerate(zip(texts, keys))
         }
         for fut in as_completed(futures):
             idx = futures[fut]
@@ -195,8 +174,28 @@ def set_cached(key: str, result: dict) -> None:
 
 # Words that carry no signal when used as the entire "reason".
 _FILLER = frozenset(
-    {"the", "a", "an", "is", "it", "of", "in", "on", "at", "to", "for",
-     "and", "or", "with", "your", "you", "we", "our", "this", "that"}
+    {
+        "the",
+        "a",
+        "an",
+        "is",
+        "it",
+        "of",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "and",
+        "or",
+        "with",
+        "your",
+        "you",
+        "we",
+        "our",
+        "this",
+        "that",
+    }
 )
 
 
@@ -337,17 +336,17 @@ def _parse_response(text: str) -> dict:
 # The local model uses a simpler 4-way split; we widen it to match ClassifiedEmail.
 _TRIAGE_MAP: dict[str, tuple[str, str, str, bool]] = {
     #           category         priority  suggested_action  requires_reply
-    "important": ("action_required", "high",   "reply",          True),
-    "promo":     ("newsletter",      "low",    "unsubscribe",     False),
-    "update":    ("notification",    "low",    "archive",         False),
-    "spam":      ("spam",            "low",    "delete",          False),
+    "important": ("action_required", "high", "reply", True),
+    "promo": ("newsletter", "low", "unsubscribe", False),
+    "update": ("notification", "low", "archive", False),
+    "spam": ("spam", "low", "delete", False),
 }
 
 # When local LLM says "keep" but category implies deletable, trust the category.
 # "archive" and "delete" are mapped directly.
 _ACTION_OVERRIDE: dict[str, str] = {
     "archive": "archive",
-    "delete":  "delete",
+    "delete": "delete",
 }
 
 
@@ -371,9 +370,7 @@ def classify_for_triage(messages: list[Message]) -> list[ClassifiedEmail]:
     mock = MockAIEngine()
 
     texts = [
-        f"From: {m.sender_name or m.sender_email}\n"
-        f"Subject: {m.headers.subject}\n"
-        f"{m.snippet[:500]}"
+        f"From: {m.sender_name or m.sender_email}\nSubject: {m.headers.subject}\n{m.snippet[:500]}"
         for m in messages
     ]
     raw_results = analyze_batch(texts, max_workers=4)

--- a/mailtrim/core/providers/__init__.py
+++ b/mailtrim/core/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Email provider abstraction — Gmail, IMAP, and future backends."""

--- a/mailtrim/core/providers/base.py
+++ b/mailtrim/core/providers/base.py
@@ -1,0 +1,83 @@
+"""Abstract email provider interface.
+
+All pipeline code (stats, purge, bulk) targets this interface.
+Provider implementations (Gmail, IMAP) are selected at the CLI boundary
+and injected — the pipeline never imports a concrete provider directly.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from mailtrim.core.gmail_client import Message
+
+
+class EmailProvider(ABC):
+    """
+    Minimal interface the mailtrim pipeline requires from any mail backend.
+
+    Concrete implementations: GmailProvider, IMAPProvider.
+    Adding a new backend requires implementing these eight methods only —
+    no changes to scoring, ranking, or CLI output logic.
+    """
+
+    # ── Read ──────────────────────────────────────────────────────────────────
+
+    @abstractmethod
+    def list_message_ids(
+        self,
+        query: str = "",
+        max_results: int | None = None,
+    ) -> list[str]:
+        """Return message IDs matching query, up to max_results."""
+
+    @abstractmethod
+    def get_messages_batch(self, ids: list[str]) -> list[Message]:
+        """Fetch full messages (headers + body) for a list of IDs."""
+
+    @abstractmethod
+    def get_messages_metadata(self, ids: list[str]) -> list[Message]:
+        """
+        Fetch lightweight metadata only (headers + size, no body).
+
+        Used by the stats pipeline where body content is never needed.
+        Implementations should make this as cheap as possible — Gmail uses
+        format=metadata, IMAP uses BODY.PEEK[HEADER.FIELDS ...] + RFC822.SIZE.
+        """
+
+    # ── Write ─────────────────────────────────────────────────────────────────
+
+    @abstractmethod
+    def batch_trash(self, ids: list[str]) -> int:
+        """Move messages to Trash. Returns count of messages acted on."""
+
+    @abstractmethod
+    def batch_delete_permanent(self, ids: list[str]) -> int:
+        """Permanently delete messages — no undo at the provider level."""
+
+    @abstractmethod
+    def batch_archive(self, ids: list[str]) -> int:
+        """Archive messages (remove from inbox, keep accessible)."""
+
+    @abstractmethod
+    def batch_label(
+        self,
+        ids: list[str],
+        add: list[str] = (),
+        remove: list[str] = (),
+    ) -> int:
+        """Add/remove labels. Label semantics are provider-specific."""
+
+    # ── Account ───────────────────────────────────────────────────────────────
+
+    @abstractmethod
+    def get_profile(self) -> dict:
+        """
+        Return account metadata as a dict with at minimum:
+            emailAddress: str
+            messagesTotal: int
+            threadsTotal: int  (may be 0 if provider doesn't support threads)
+        """
+
+    def get_email_address(self) -> str:
+        return self.get_profile()["emailAddress"]

--- a/mailtrim/core/providers/factory.py
+++ b/mailtrim/core/providers/factory.py
@@ -1,0 +1,57 @@
+"""Provider factory — select and construct the right EmailProvider from CLI config.
+
+This is the only place that imports both GmailProvider and IMAPProvider.
+All other code depends only on the EmailProvider interface.
+"""
+
+from __future__ import annotations
+
+from mailtrim.core.providers.base import EmailProvider
+
+
+def get_provider(
+    provider: str = "gmail",
+    *,
+    # IMAP-specific
+    imap_server: str = "",
+    imap_user: str = "",
+    imap_password: str = "",
+    imap_port: int = 993,
+    imap_folder: str = "INBOX",
+) -> EmailProvider:
+    """
+    Construct and return the appropriate EmailProvider.
+
+    Args:
+        provider:      "gmail" or "imap"
+        imap_server:   Required when provider="imap"
+        imap_user:     Required when provider="imap"
+        imap_password: Required when provider="imap"
+        imap_port:     IMAP SSL port (default 993)
+        imap_folder:   Default folder to operate on (default INBOX)
+
+    Raises:
+        ValueError: if provider is unknown or IMAP credentials are missing
+    """
+    if provider == "gmail":
+        from mailtrim.core.providers.gmail import GmailProvider
+
+        return GmailProvider()
+
+    if provider == "imap":
+        if not imap_server or not imap_user or not imap_password:
+            raise ValueError(
+                "IMAP provider requires --imap-server, --imap-user, and --imap-password. "
+                "Use an app password, not your account password."
+            )
+        from mailtrim.core.providers.imap import IMAPProvider
+
+        return IMAPProvider(
+            server=imap_server,
+            user=imap_user,
+            password=imap_password,
+            port=imap_port,
+            folder=imap_folder,
+        )
+
+    raise ValueError(f"Unknown provider '{provider}'. Valid options: gmail, imap")

--- a/mailtrim/core/providers/gmail.py
+++ b/mailtrim/core/providers/gmail.py
@@ -1,0 +1,81 @@
+"""Gmail provider — wraps GmailClient to implement EmailProvider.
+
+All existing GmailClient behaviour is preserved exactly.
+This file is the only place that knows about Gmail internals;
+the rest of the pipeline sees only EmailProvider.
+"""
+
+from __future__ import annotations
+
+from mailtrim.config import get_settings
+from mailtrim.core.gmail_client import GmailClient, Message, _chunks
+from mailtrim.core.providers.base import EmailProvider
+
+
+class GmailProvider(EmailProvider):
+    """
+    Thin adapter: EmailProvider interface → GmailClient implementation.
+
+    Constructed by the CLI and injected into the pipeline.  Nothing in
+    stats / bulk / scoring imports this class directly.
+    """
+
+    def __init__(self, client: GmailClient | None = None) -> None:
+        self._client = client or GmailClient()
+
+    # ── Read ──────────────────────────────────────────────────────────────────
+
+    def list_message_ids(
+        self,
+        query: str = "",
+        max_results: int | None = None,
+    ) -> list[str]:
+        return self._client.list_message_ids(query=query, max_results=max_results)
+
+    def get_messages_batch(self, ids: list[str]) -> list[Message]:
+        return self._client.get_messages_batch(ids)
+
+    def get_messages_metadata(self, ids: list[str]) -> list[Message]:
+        """Metadata-only fetch using Gmail's format=metadata (no body download)."""
+        settings = get_settings()
+        results: list[Message] = []
+        for chunk in _chunks(ids, settings.gmail_batch_size):
+            results.extend(self._client._fetch_batch(chunk, format="metadata"))
+        return results
+
+    # ── Write ─────────────────────────────────────────────────────────────────
+
+    def batch_trash(self, ids: list[str]) -> int:
+        return self._client.batch_trash(ids)
+
+    def batch_delete_permanent(self, ids: list[str]) -> int:
+        return self._client.batch_delete_permanent(ids)
+
+    def batch_archive(self, ids: list[str]) -> int:
+        return self._client.batch_archive(ids)
+
+    def batch_label(
+        self,
+        ids: list[str],
+        add: list[str] = (),
+        remove: list[str] = (),
+    ) -> int:
+        return self._client.batch_label(ids, add=list(add), remove=list(remove))
+
+    # ── Account ───────────────────────────────────────────────────────────────
+
+    def get_profile(self) -> dict:
+        return self._client.get_profile()
+
+    def get_email_address(self) -> str:
+        return self._client.get_email_address()
+
+    # ── Pass-through for Gmail-only features ──────────────────────────────────
+    # Code that requires Gmail-specific capabilities (labels, OAuth, unsubscribe)
+    # accesses the underlying client directly. The provider abstraction is only
+    # for the stats/purge pipeline.
+
+    @property
+    def gmail_client(self) -> GmailClient:
+        """Direct access for Gmail-specific operations (labels, drafts, etc.)."""
+        return self._client

--- a/mailtrim/core/providers/imap.py
+++ b/mailtrim/core/providers/imap.py
@@ -1,0 +1,615 @@
+"""IMAP provider — stdlib-only implementation of EmailProvider.
+
+Design constraints:
+  - Zero new dependencies: imaplib, email, email.header, re only
+  - Single persistent connection per instance (no reconnect loops)
+  - Metadata-first strategy: fetch headers + size, body only when requested
+  - Batch fetch: FETCH uid1,uid2,...,uidN in one round-trip
+  - Fail clearly on auth errors; fail silently on individual message parse errors
+  - Never log credentials
+
+Performance targets:
+  - 300 emails metadata fetch < 10s on a local network
+  - Single IMAP connection reused across all calls
+
+Security:
+  - Credentials are never stored; connection object holds the session
+  - Always use SSL (IMAP4_SSL); plaintext IMAP is not supported
+"""
+
+from __future__ import annotations
+
+import email
+import email.header
+import imaplib
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
+from mailtrim.core.gmail_client import Message, MessageHeader
+from mailtrim.core.providers.base import EmailProvider
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+_DEFAULT_PORT = 993
+_BATCH_SIZE = 100  # UIDs per FETCH command
+_MAX_BODY_CHARS = 400  # body preview truncation
+_CONNECT_TIMEOUT = 10  # seconds
+
+# Common IMAP folder names for Trash and Archive across providers
+_TRASH_FOLDERS = ["Trash", "[Gmail]/Trash", "Deleted Messages", "Deleted Items"]
+_ARCHIVE_FOLDERS = ["Archive", "[Gmail]/All Mail", "All Mail"]
+
+
+# ── IMAP query translation ────────────────────────────────────────────────────
+
+
+def _gmail_query_to_imap(query: str) -> tuple[str, str]:
+    """
+    Translate a Gmail query string to (folder, IMAP SEARCH criteria).
+
+    Handles the subset of Gmail operators used by mailtrim:
+        in:inbox          → INBOX, ALL
+        in:anywhere       → INBOX, ALL  (full-folder walk not implemented; INBOX is the
+                            primary target; users can pass --imap-folder for other folders)
+        from:addr         → FROM "addr"
+        older_than:Nd     → BEFORE <date>
+        subject:text      → SUBJECT "text"
+        category:*        → ALL  (no IMAP equivalent; ignored gracefully)
+        label:*           → ALL  (ignored)
+
+    Returns (folder_name, search_criteria).
+    """
+    folder = "INBOX"
+    parts: list[str] = []
+
+    # Scope modifiers — folder selection only, no search criteria
+    if "in:anywhere" in query:
+        folder = "INBOX"  # simplified; see note above
+    elif "in:inbox" in query:
+        folder = "INBOX"
+
+    # FROM filter
+    m = re.search(r"from:([^\s]+)", query)
+    if m:
+        parts.append(f'FROM "{m.group(1)}"')
+
+    # Age filter — older_than:Nd
+    m = re.search(r"older_than:(\d+)d", query)
+    if m:
+        days = int(m.group(1))
+        cutoff = datetime.now(tz=timezone.utc).timestamp() - days * 86400
+        dt = datetime.fromtimestamp(cutoff, tz=timezone.utc)
+        # IMAP BEFORE uses DD-Mon-YYYY format
+        parts.append(f'BEFORE "{dt.strftime("%d-%b-%Y")}"')
+
+    # Subject filter
+    m = re.search(r'subject:"([^"]+)"', query)
+    if m:
+        parts.append(f'SUBJECT "{m.group(1)}"')
+
+    criteria = " ".join(parts) if parts else "ALL"
+    return folder, criteria
+
+
+# ── Header parsing ────────────────────────────────────────────────────────────
+
+
+def _decode_header_value(raw: str | bytes | None) -> str:
+    """Decode a potentially RFC2047-encoded header value to a plain string."""
+    if not raw:
+        return ""
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8", errors="replace")
+    decoded_parts = []
+    for part, charset in email.header.decode_header(raw):
+        if isinstance(part, bytes):
+            decoded_parts.append(part.decode(charset or "utf-8", errors="replace"))
+        else:
+            decoded_parts.append(part)
+    return "".join(decoded_parts)
+
+
+def _parse_imap_date(date_str: str) -> int:
+    """Parse an email Date header to milliseconds since epoch. Returns 0 on failure."""
+    try:
+        dt = parsedate_to_datetime(date_str)
+        return int(dt.timestamp() * 1000)
+    except Exception:
+        return 0
+
+
+def _extract_text_from_message(msg: email.message.Message) -> tuple[str, str]:
+    """
+    Walk a parsed email.message.Message and extract plain text and HTML.
+    Returns (text, html), each truncated to _MAX_BODY_CHARS.
+    Handles multipart, encoding errors, and malformed payloads silently.
+    """
+    text = ""
+    html = ""
+    try:
+        if msg.is_multipart():
+            for part in msg.walk():
+                ct = part.get_content_type()
+                if ct == "text/plain" and not text:
+                    payload = part.get_payload(decode=True)
+                    if payload:
+                        charset = part.get_content_charset() or "utf-8"
+                        text = payload.decode(charset, errors="replace")[:_MAX_BODY_CHARS]
+                elif ct == "text/html" and not html:
+                    payload = part.get_payload(decode=True)
+                    if payload:
+                        charset = part.get_content_charset() or "utf-8"
+                        html = payload.decode(charset, errors="replace")[:_MAX_BODY_CHARS]
+        else:
+            payload = msg.get_payload(decode=True)
+            if payload:
+                charset = msg.get_content_charset() or "utf-8"
+                content = payload.decode(charset, errors="replace")[:_MAX_BODY_CHARS]
+                if msg.get_content_type() == "text/html":
+                    html = content
+                else:
+                    text = content
+    except Exception as exc:
+        logger.debug("Body extraction failed: %s", exc)
+    return text, html
+
+
+def _strip_html(html: str) -> str:
+    """Strip HTML tags for plain-text snippet generation."""
+    return re.sub(r"<[^>]+>", " ", html).strip()
+
+
+# ── Message construction ──────────────────────────────────────────────────────
+
+
+@dataclass
+class _IMAPRawMessage:
+    """Intermediate parsed form before converting to the shared Message type."""
+
+    uid: str
+    subject: str = ""
+    from_: str = ""
+    date: str = ""
+    list_unsubscribe: str = ""
+    size_bytes: int = 0
+    internal_date_ms: int = 0
+    body_text: str = ""
+    body_html: str = ""
+    flags: list[str] = field(default_factory=list)
+
+
+def _raw_to_message(raw: _IMAPRawMessage, folder: str = "INBOX") -> Message:
+    """Convert an _IMAPRawMessage to the shared Message dataclass."""
+    label_ids = []
+    if folder.upper() == "INBOX":
+        label_ids.append("INBOX")
+    if r"\Seen" not in raw.flags:
+        label_ids.append("UNREAD")
+
+    snippet = raw.body_text[:200] if raw.body_text else _strip_html(raw.body_html)[:200]
+
+    return Message(
+        id=raw.uid,
+        thread_id="",  # IMAP has no thread concept at the protocol level
+        label_ids=label_ids,
+        snippet=snippet,
+        headers=MessageHeader(
+            subject=raw.subject,
+            from_=raw.from_,
+            date=raw.date,
+            list_unsubscribe=raw.list_unsubscribe,
+        ),
+        body_text=raw.body_text,
+        body_html=raw.body_html,
+        size_estimate=raw.size_bytes,
+        internal_date=raw.internal_date_ms,
+    )
+
+
+# ── IMAP response parsing ─────────────────────────────────────────────────────
+
+
+def _parse_uid_search(response: list[bytes]) -> list[str]:
+    """Extract UID integers from a UID SEARCH response."""
+    uids: list[str] = []
+    for line in response:
+        if line:
+            uids.extend(line.decode("ascii", errors="replace").split())
+    return [u for u in uids if u.isdigit()]
+
+
+def _parse_fetch_response(
+    fetch_data: list,
+    metadata_only: bool = True,
+) -> list[_IMAPRawMessage]:
+    """
+    Parse imaplib FETCH response into _IMAPRawMessage list.
+
+    imaplib returns alternating (header_bytes, b')') tuples.
+    Each header_bytes contains:
+        <UID> (RFC822.SIZE <n> INTERNALDATE "<date>" FLAGS (<flags>)
+               BODY[HEADER.FIELDS (...)] {<n>}
+        <header-block>
+
+    For full fetch (metadata_only=False), BODY[] contains the full RFC822 message.
+    """
+    results: list[_IMAPRawMessage] = []
+    i = 0
+    while i < len(fetch_data):
+        item = fetch_data[i]
+        i += 1
+
+        # imaplib interleaves (tuple, b')') — skip plain bytes sentinels
+        if not isinstance(item, tuple):
+            continue
+
+        descriptor, raw_headers = item[0], item[1]
+        descriptor_str = (
+            descriptor.decode("ascii", errors="replace")
+            if isinstance(descriptor, bytes)
+            else str(descriptor)
+        )
+
+        # Extract UID
+        uid_match = re.search(r"UID\s+(\d+)", descriptor_str, re.IGNORECASE)
+        uid = uid_match.group(1) if uid_match else str(i)
+
+        # Extract RFC822.SIZE
+        size_match = re.search(r"RFC822\.SIZE\s+(\d+)", descriptor_str, re.IGNORECASE)
+        size_bytes = int(size_match.group(1)) if size_match else 0
+
+        # Extract INTERNALDATE
+        date_match = re.search(r'INTERNALDATE\s+"([^"]+)"', descriptor_str, re.IGNORECASE)
+        internal_date_str = date_match.group(1) if date_match else ""
+        internal_date_ms = _parse_imap_date(internal_date_str) if internal_date_str else 0
+
+        # Extract FLAGS
+        flags_match = re.search(r"FLAGS\s+\(([^)]*)\)", descriptor_str, re.IGNORECASE)
+        flags = flags_match.group(1).split() if flags_match else []
+
+        # Parse headers
+        raw_msg = _IMAPRawMessage(
+            uid=uid, size_bytes=size_bytes, internal_date_ms=internal_date_ms, flags=flags
+        )
+
+        if isinstance(raw_headers, bytes):
+            try:
+                parsed = email.message_from_bytes(raw_headers)
+                raw_msg.subject = _decode_header_value(parsed.get("Subject", ""))
+                raw_msg.from_ = _decode_header_value(parsed.get("From", ""))
+                raw_msg.date = _decode_header_value(parsed.get("Date", ""))
+                raw_msg.list_unsubscribe = _decode_header_value(parsed.get("List-Unsubscribe", ""))
+
+                if not metadata_only:
+                    raw_msg.body_text, raw_msg.body_html = _extract_text_from_message(parsed)
+            except Exception as exc:
+                logger.debug("Header parse failed for UID %s: %s", uid, exc)
+
+        results.append(raw_msg)
+
+    return results
+
+
+# ── Main provider ─────────────────────────────────────────────────────────────
+
+
+class IMAPProvider(EmailProvider):
+    """
+    IMAP email provider using stdlib imaplib.
+
+    One connection is opened on first use and reused for all operations.
+    SSL is always enforced (IMAP4_SSL).
+
+    Args:
+        server:   IMAP server hostname (e.g. imap.gmail.com, outlook.office365.com)
+        user:     Full email address used for login
+        password: App password (never a regular account password for 2FA accounts)
+        port:     SSL port, default 993
+        folder:   Default folder to operate on, default INBOX
+    """
+
+    def __init__(
+        self,
+        server: str,
+        user: str,
+        password: str,
+        port: int = _DEFAULT_PORT,
+        folder: str = "INBOX",
+    ) -> None:
+        self._server = server
+        self._user = user
+        self._password = password  # never logged
+        self._port = port
+        self._default_folder = folder
+        self._conn: imaplib.IMAP4_SSL | None = None
+        self._selected_folder: str | None = None
+
+    # ── Connection management ─────────────────────────────────────────────────
+
+    def _connect(self) -> imaplib.IMAP4_SSL:
+        """Open and authenticate an SSL connection. Raises on auth failure."""
+        conn = imaplib.IMAP4_SSL(self._server, self._port)
+        typ, data = conn.login(self._user, self._password)
+        if typ != "OK":
+            raise ConnectionError(f"IMAP login failed: {data}")
+        return conn
+
+    def _ensure_connected(self) -> imaplib.IMAP4_SSL:
+        """Return the active connection, reconnecting once if it has gone stale."""
+        if self._conn is None:
+            self._conn = self._connect()
+            self._selected_folder = None
+        else:
+            # NOOP to check liveness; reconnect if the server has closed the session
+            try:
+                self._conn.noop()
+            except Exception:
+                logger.debug("IMAP connection stale, reconnecting")
+                try:
+                    self._conn.logout()
+                except Exception:
+                    pass
+                self._conn = self._connect()
+                self._selected_folder = None
+        return self._conn
+
+    def _select(self, folder: str = "INBOX") -> None:
+        """SELECT a mailbox if not already selected."""
+        conn = self._ensure_connected()
+        if self._selected_folder != folder:
+            typ, data = conn.select(folder, readonly=False)
+            if typ != "OK":
+                raise ConnectionError(f"Cannot SELECT {folder}: {data}")
+            self._selected_folder = folder
+
+    def _find_folder(self, candidates: list[str]) -> str | None:
+        """Return the first folder from candidates that exists on the server."""
+        conn = self._ensure_connected()
+        typ, mailboxes = conn.list()
+        if typ != "OK":
+            return None
+        existing = []
+        for mb in mailboxes:
+            if isinstance(mb, bytes):
+                existing.append(mb.decode("utf-8", errors="replace"))
+        for candidate in candidates:
+            if any(candidate in box for box in existing):
+                return candidate
+        return None
+
+    # ── Read ──────────────────────────────────────────────────────────────────
+
+    def list_message_ids(
+        self,
+        query: str = "",
+        max_results: int | None = None,
+    ) -> list[str]:
+        """
+        Return message UIDs matching query, up to max_results.
+
+        Gmail query strings are translated to IMAP SEARCH criteria.
+        Category/label operators that have no IMAP equivalent are ignored
+        gracefully — the search falls back to ALL.
+        """
+        folder, criteria = _gmail_query_to_imap(query or "in:inbox")
+        self._select(folder)
+        conn = self._ensure_connected()
+
+        typ, data = conn.uid("SEARCH", None, criteria)
+        if typ != "OK":
+            logger.warning("IMAP SEARCH failed: %s", data)
+            return []
+
+        uids = _parse_uid_search(data)
+        if max_results:
+            uids = uids[:max_results]
+        return uids
+
+    def get_messages_batch(self, ids: list[str]) -> list[Message]:
+        """Fetch full messages (headers + body) for a list of UIDs."""
+        return self._fetch_batch(ids, metadata_only=False)
+
+    def get_messages_metadata(self, ids: list[str]) -> list[Message]:
+        """
+        Fetch lightweight metadata only — headers + size, no body.
+
+        Uses BODY.PEEK[HEADER.FIELDS ...] so the server marks nothing as read.
+        """
+        return self._fetch_batch(ids, metadata_only=True)
+
+    def _fetch_batch(self, ids: list[str], metadata_only: bool = True) -> list[Message]:
+        """
+        Core fetch implementation — batches UIDs into groups of _BATCH_SIZE
+        to avoid oversized FETCH commands.
+        """
+        if not ids:
+            return []
+
+        folder, _ = _gmail_query_to_imap("in:inbox")
+        self._select(folder)
+        conn = self._ensure_connected()
+
+        if metadata_only:
+            fetch_items = (
+                "(UID RFC822.SIZE INTERNALDATE FLAGS "
+                "BODY.PEEK[HEADER.FIELDS (FROM SUBJECT DATE LIST-UNSUBSCRIBE)])"
+            )
+        else:
+            fetch_items = "(UID RFC822.SIZE INTERNALDATE FLAGS BODY.PEEK[])"
+
+        results: list[Message] = []
+        for i in range(0, len(ids), _BATCH_SIZE):
+            chunk = ids[i : i + _BATCH_SIZE]
+            uid_set = ",".join(chunk)
+            try:
+                typ, data = conn.uid("FETCH", uid_set, fetch_items)
+                if typ != "OK":
+                    logger.warning("IMAP FETCH failed for chunk starting %s: %s", chunk[0], data)
+                    continue
+                raw_msgs = _parse_fetch_response(data, metadata_only=metadata_only)
+                results.extend(_raw_to_message(r, folder=folder) for r in raw_msgs)
+            except Exception as exc:
+                logger.warning("IMAP FETCH chunk error: %s", exc)
+        return results
+
+    # ── Write ─────────────────────────────────────────────────────────────────
+
+    def batch_trash(self, ids: list[str]) -> int:
+        r"""
+        Move messages to the Trash folder.
+        Falls back to \Deleted flag + EXPUNGE if MOVE is unavailable.
+        """
+        if not ids:
+            return 0
+        self._select(self._default_folder)
+        conn = self._ensure_connected()
+
+        trash_folder = self._find_folder(_TRASH_FOLDERS)
+        uid_set = ",".join(ids)
+        count = 0
+
+        if trash_folder:
+            try:
+                typ, _ = conn.uid("MOVE", uid_set, trash_folder)
+                if typ == "OK":
+                    return len(ids)
+            except imaplib.IMAP4.error:
+                pass  # MOVE not supported — fall through to STORE+EXPUNGE
+
+        # Fallback: flag as deleted and expunge
+        try:
+            conn.uid("STORE", uid_set, "+FLAGS", r"(\Deleted)")
+            conn.expunge()
+            count = len(ids)
+        except Exception as exc:
+            logger.warning("IMAP batch_trash fallback failed: %s", exc)
+
+        return count
+
+    def batch_delete_permanent(self, ids: list[str]) -> int:
+        r"""Permanently delete messages — flag \Deleted and EXPUNGE immediately."""
+        if not ids:
+            return 0
+        self._select(self._default_folder)
+        conn = self._ensure_connected()
+        uid_set = ",".join(ids)
+        try:
+            conn.uid("STORE", uid_set, "+FLAGS", r"(\Deleted)")
+            conn.expunge()
+            return len(ids)
+        except Exception as exc:
+            logger.warning("IMAP batch_delete_permanent failed: %s", exc)
+            return 0
+
+    def batch_archive(self, ids: list[str]) -> int:
+        """
+        Archive messages — move to Archive/All Mail folder.
+        If no archive folder is found, removes the INBOX flag instead.
+        """
+        if not ids:
+            return 0
+        self._select(self._default_folder)
+        conn = self._ensure_connected()
+        uid_set = ",".join(ids)
+
+        archive_folder = self._find_folder(_ARCHIVE_FOLDERS)
+        if archive_folder:
+            try:
+                typ, _ = conn.uid("MOVE", uid_set, archive_folder)
+                if typ == "OK":
+                    return len(ids)
+            except imaplib.IMAP4.error:
+                pass
+
+        # Fallback: mark as seen (closest to "archive" on servers without MOVE)
+        try:
+            conn.uid("STORE", uid_set, "+FLAGS", r"(\Seen)")
+            return len(ids)
+        except Exception as exc:
+            logger.warning("IMAP batch_archive fallback failed: %s", exc)
+            return 0
+
+    def batch_label(
+        self,
+        ids: list[str],
+        add: list[str] = (),
+        remove: list[str] = (),
+    ) -> int:
+        r"""
+        IMAP has no label concept — map to flag operations.
+
+        Known mappings:
+          UNREAD → \Seen (remove flag to mark unread, add to mark read)
+          All others → logged and skipped.
+        """
+        if not ids:
+            return 0
+        conn = self._ensure_connected()
+        uid_set = ",".join(ids)
+
+        for label in add:
+            if label == "UNREAD":
+                conn.uid("STORE", uid_set, "-FLAGS", r"(\Seen)")
+        for label in remove:
+            if label == "UNREAD":
+                conn.uid("STORE", uid_set, "+FLAGS", r"(\Seen)")
+            elif label == "INBOX":
+                # Move out of inbox = archive
+                self.batch_archive(ids)
+                return len(ids)
+
+        return len(ids)
+
+    # ── Account ───────────────────────────────────────────────────────────────
+
+    def get_profile(self) -> dict:
+        """
+        Return account summary. messagesTotal comes from STATUS(MESSAGES).
+        threadsTotal is 0 — IMAP has no native thread concept.
+        """
+        conn = self._ensure_connected()
+        messages_total = 0
+        try:
+            typ, data = conn.status("INBOX", "(MESSAGES)")
+            if typ == "OK" and data:
+                m = re.search(r"MESSAGES\s+(\d+)", data[0].decode("ascii", errors="replace"))
+                if m:
+                    messages_total = int(m.group(1))
+        except Exception as exc:
+            logger.debug("IMAP STATUS failed: %s", exc)
+
+        return {
+            "emailAddress": self._user,
+            "messagesTotal": messages_total,
+            "threadsTotal": 0,
+        }
+
+    def get_email_address(self) -> str:
+        return self._user
+
+    # ── Cleanup ───────────────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        """Gracefully close the IMAP connection."""
+        if self._conn:
+            try:
+                if self._selected_folder:
+                    self._conn.close()
+                self._conn.logout()
+            except Exception:
+                pass
+            finally:
+                self._conn = None
+                self._selected_folder = None
+
+    def __enter__(self) -> "IMAPProvider":
+        self._ensure_connected()
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.close()

--- a/mailtrim/core/sender_stats.py
+++ b/mailtrim/core/sender_stats.py
@@ -55,6 +55,90 @@ _TRANSACTIONAL_KEYWORDS: frozenset[str] = frozenset(
 _TRANSACTIONAL_PENALTY = 25  # pts deducted when transactional keywords are found
 
 
+# ── Sender risk classification ────────────────────────────────────────────────
+
+# Domain/name fragments that indicate sensitive senders (banks, healthcare,
+# schools, government, legal).  Matching any of these overrides the confidence
+# score — we never surface auto-delete actions for these senders.
+_SENSITIVE_DOMAIN_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "bank",
+        "icici",
+        "hdfc",
+        "sbi",
+        "axis",
+        "kotak",
+        "chase",
+        "citi",
+        "barclays",
+        "bankofamerica",
+        "amex",
+        "americanexpress",
+        "fidelity",
+        "vanguard",
+        "schwab",
+        "finance",
+        "financial",
+        "invest",
+        "brokerage",
+        "insurance",
+        "mortgage",
+        "loan",
+        "credit",
+        "hospital",
+        "clinic",
+        "health",
+        "medical",
+        "medicare",
+        "pharmacy",
+        "school",
+        "district",
+        "university",
+        "college",
+        "academy",
+        "gov",
+        "irs",
+        "court",
+        "legal",
+        "attorney",
+    }
+)
+
+# Domain/name fragments that confirm safe bulk/marketing senders.
+# Matching any of these + moderate confidence → "Safe to clean".
+_SAFE_SENDER_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "newsletter",
+        "noreply",
+        "no-reply",
+        "donotreply",
+        "promo",
+        "promotions",
+        "marketing",
+        "deals",
+        "offers",
+        "sale",
+        "jobs",
+        "careers",
+        "jobalert",
+        "digest",
+        "updates",
+        "notifications",
+        "linkedin",
+        "indeed",
+        "glassdoor",
+        "naukri",
+        "utest",
+        "github",
+        "gitlab",
+        "jira",
+        "atlassian",
+        "medium",
+        "substack",
+    }
+)
+
+
 # ── Age formatting ────────────────────────────────────────────────────────────
 
 
@@ -257,8 +341,8 @@ def confidence_safety_label(score: int) -> str:
     if score >= 70:
         return "Safe to clean"
     if score >= 40:
-        return "Low risk"
-    return "Review first"
+        return "Needs review"
+    return "Sensitive / personal"
 
 
 def risk_tier_icon(confidence: int) -> str:
@@ -295,6 +379,64 @@ def confidence_reason(g: SenderGroup) -> str:
     if any(kw in subjects_lower for kw in _TRANSACTIONAL_KEYWORDS):
         parts.append("transactional keywords detected")
     return " + ".join(parts) if parts else "limited signals"
+
+
+def classify_sender_risk(g: SenderGroup) -> str:
+    """
+    Classify a sender's inherent risk: "sensitive", "safe", or "review".
+
+    "sensitive" → bank/healthcare/school/legal — never auto-delete.
+                  Overrides unsubscribe signal and confidence score.
+    "safe"      → confirmed newsletter/promo/marketing — safe to bulk-clean.
+    "review"    → everything else — defer to confidence score.
+    """
+    combined = f"{g.domain} {(g.sender_name or '')} {g.sender_email}".lower()
+    if any(kw in combined for kw in _SENSITIVE_DOMAIN_KEYWORDS):
+        return "sensitive"
+    if any(kw in combined for kw in _SAFE_SENDER_KEYWORDS):
+        return "safe"
+    return "review"
+
+
+def sender_risk_tier_from_conf(g: SenderGroup, conf: int) -> tuple[str, str, str]:
+    """
+    Return (label, icon, color) using sender classification + explicit conf value.
+
+    Sensitive senders always → 🔴 regardless of confidence (prevents a bank
+    with List-Unsubscribe from being labelled "Safe to clean").
+    Confirmed safe senders with modest confidence → 🟢.
+    Everything else uses the confidence thresholds, but low-confidence non-sensitive
+    senders get 🟡 "Needs review" instead of 🔴 to avoid overfiring red labels.
+    """
+    risk_class = classify_sender_risk(g)
+    if risk_class == "sensitive":
+        return ("Sensitive / personal", "🔴", "red")
+    if risk_class == "safe" and conf >= 30:
+        return ("Safe to clean", "🟢", "green")
+    if conf >= 70:
+        return ("Safe to clean", "🟢", "green")
+    if conf >= 40:
+        return ("Needs review", "🟡", "yellow")
+    # Low-confidence, non-sensitive → uncertain, not dangerous
+    return ("Needs review", "🟡", "yellow")
+
+
+def sender_risk_tier(g: SenderGroup) -> tuple[str, str, str]:
+    """Return (label, icon, color) using rule-based confidence only."""
+    return sender_risk_tier_from_conf(g, compute_confidence_score(g))
+
+
+def confidence_description(score: int) -> str:
+    """Human-readable interpretation of a confidence score."""
+    if score >= 80:
+        return "Likely safe"
+    if score >= 60:
+        return "Probably safe"
+    if score >= 40:
+        return "Needs manual review"
+    if score >= 20:
+        return "Needs manual review"
+    return "Very risky to automate"
 
 
 # ── Time estimation ───────────────────────────────────────────────────────────
@@ -369,25 +511,30 @@ def generate_headline_insight(
     reclaim_pct: float,
     rec_count: int,
     reclaimable_mb_val: float,
+    recommendations: "list[Recommendation] | None" = None,
 ) -> str:
     """
     Generate a punchy, personalised one-liner that is the very first thing
-    the user reads. Designed to immediately convey the scale of the problem
-    and make the tool feel like it "gets" them.
+    the user reads.
 
     Decision logic (most dramatic fact wins):
     - Heavy clutter (≥ 30%): lead with the percentage
     - Large absolute size (≥ 50 MB): lead with the MB
     - Old inbox (≥ 365d oldest): lead with time
-    - High-volume, small files: acknowledge the noise
-    - Clean inbox: celebrate it
+    - Low but non-zero savings: acknowledge small wins
+    - No safe actions, only review items: correct messaging
+    - Truly clean inbox: celebrate it
+
+    The ``recommendations`` list is used to pick the right empty-state message
+    so we never say "nothing to delete" while the tool simultaneously shows
+    manual-review items in the sections below.
     """
     if insights.total_scanned == 0:
         return "📭 No emails found matching the scan query."
 
     if reclaim_pct >= 30:
         return (
-            f"💥 {reclaim_pct:.0f}% of your inbox is clutter — caused by just "
+            f"💥 {reclaim_pct:.0f}% of scanned emails appear reclaimable — caused by just "
             f"{rec_count} sender{'s' if rec_count != 1 else ''}. "
             f"{reclaimable_mb_val} MB gone in one command."
         )
@@ -407,13 +554,28 @@ def generate_headline_insight(
         )
 
     if reclaimable_mb_val > 0:
+        # Distinguish small-but-real wins from "nothing"
+        if reclaimable_mb_val < 10:
+            return (
+                f"🧹 Small cleanup wins available — "
+                f"{rec_count} sender{'s' if rec_count != 1 else ''} worth tidying."
+            )
         return (
             f"📬 Scanned {insights.unique_senders} senders — "
             f"{rec_count} sender{'s' if rec_count != 1 else ''} "
             f"responsible for {reclaimable_mb_val} MB you don't need."
         )
 
-    return "✅ Inbox looking clean — nothing worth deleting right now."
+    # No reclaimable storage — but may still have review-only items
+    recs = recommendations or []
+    has_safe = any(classify_sender_risk(r.sender) != "sensitive" for r in recs if r.actions)
+    has_any = bool(recs)
+
+    if has_safe:
+        return "🔍 You have a few easy cleanup wins available."
+    if has_any:
+        return "📋 Inbox mostly clean — a few items need manual review."
+    return "✅ Inbox looking clean — nothing worth cleaning right now."
 
 
 # ── Reading time estimate ─────────────────────────────────────────────────────
@@ -608,12 +770,23 @@ def generate_recommendations(
       mailtrim purge --domain example.com --keep 10
       mailtrim purge --domain example.com --older-than 90
     """
-    by_score = sorted(groups, key=lambda g: g.impact_score, reverse=True)
+
+    # Rank by impact weighted by confidence so low-confidence senders don't
+    # crowd out safer picks.  Weight maps [0,100] confidence to [0.1, 1.0].
+    def _rank(g: SenderGroup) -> float:
+        conf = compute_confidence_score(g)
+        weight = 0.1 + (conf / 100) * 0.9
+        return g.impact_score * weight
+
+    by_score = sorted(groups, key=_rank, reverse=True)
     recs: list[Recommendation] = []
 
-    for g in by_score[:top_n]:
+    for g in by_score:  # iterate all candidates; break once we have top_n valid recs
+        if len(recs) >= top_n:
+            break
         actions: list[Action] = []
         domain = g.domain
+        risk_class = classify_sender_risk(g)
 
         # Use domain-level totals when available so savings and thresholds
         # match what `purge --domain` will actually delete.
@@ -622,71 +795,99 @@ def generate_recommendations(
         count = d.count if d else g.count
         days = g.inbox_days  # sender-level age is the right signal here
 
-        # Action 1: always offer "delete all" if there's meaningful size
-        if size_mb >= 1:
+        if risk_class == "sensitive":
+            # Never offer auto-delete for banks, schools, healthcare, legal.
+            # --dry-run previews what would be deleted without touching anything.
             actions.append(
                 Action(
-                    label="Delete all",
-                    savings_mb=size_mb,
-                    savings_exact=True,
-                    command=f"mailtrim purge --domain {domain} --yes",
-                )
-            )
-
-        # Action 2: depends on the sender profile
-        if size_mb < 3 and count >= 30:
-            # High noise, low storage — mark as read first, then age-based delete
-            actions.append(
-                Action(
-                    label="Mark all as read",
+                    label="Review manually",
                     savings_mb=0,
                     savings_exact=True,
-                    command=f"mailtrim bulk mark-read --domain {domain}",
+                    command=f"mailtrim purge --domain {domain} --dry-run",
                 )
             )
-            actions.append(
-                Action(
-                    label="Delete older than 30d",
-                    savings_mb=round(size_mb * 0.85, 1),
-                    savings_exact=False,
-                    command=f"mailtrim purge --domain {domain} --older-than 30",
+            if count > 5:
+                keep = 5
+                fraction = max(0, (count - keep) / count)
+                actions.append(
+                    Action(
+                        label=f"Keep latest {keep}",
+                        savings_mb=round(size_mb * fraction, 1),
+                        savings_exact=False,
+                        command=f"mailtrim purge --domain {domain} --keep {keep}",
+                    )
                 )
-            )
+        else:
+            # Action 1: always offer "delete all" if there's meaningful size
+            if size_mb >= 1:
+                actions.append(
+                    Action(
+                        label="Delete all",
+                        savings_mb=size_mb,
+                        savings_exact=True,
+                        command=f"mailtrim purge --domain {domain} --yes",
+                    )
+                )
 
-        elif count >= 50 and days >= 60:
-            # High-count, long history — keep a small recent tail
-            keep = 10
-            fraction_deleted = max(0, (count - keep) / count)
-            actions.append(
-                Action(
-                    label=f"Keep last {keep}",
-                    savings_mb=round(size_mb * fraction_deleted, 1),
-                    savings_exact=False,
-                    command=f"mailtrim purge --domain {domain} --keep {keep}",
+            # Action 2: depends on the sender profile
+            if size_mb < 3 and count >= 30:
+                # High noise, low storage — mark as read first, then age-based delete
+                actions.append(
+                    Action(
+                        label="Mark all as read",
+                        savings_mb=0,
+                        savings_exact=True,
+                        command=f"mailtrim bulk mark-read --domain {domain}",
+                    )
                 )
-            )
+                if days >= 30:
+                    actions.append(
+                        Action(
+                            label="Delete older than 30d",
+                            savings_mb=round(size_mb * 0.85, 1),
+                            savings_exact=False,
+                            command=f"mailtrim purge --domain {domain} --older-than 30",
+                        )
+                    )
 
-        elif days >= 60:
-            # Old clutter — delete by age
-            actions.append(
-                Action(
-                    label="Delete older than 90d",
-                    savings_mb=round(size_mb * 0.85, 1),
-                    savings_exact=False,
-                    command=f"mailtrim purge --domain {domain} --older-than 90",
+            elif count >= 50 and days >= 60:
+                # High-count, long history — keep a small recent tail
+                keep = 10
+                fraction_deleted = max(0, (count - keep) / count)
+                actions.append(
+                    Action(
+                        label=f"Keep last {keep}",
+                        savings_mb=round(size_mb * fraction_deleted, 1),
+                        savings_exact=False,
+                        command=f"mailtrim purge --domain {domain} --keep {keep}",
+                    )
                 )
-            )
 
-        if size_mb < 1:
-            # Too small for size-based actions; still useful as a noise cleanup
-            actions.append(
-                Action(
-                    label="Delete older than 30d",
-                    savings_mb=round(size_mb * 0.8, 1),
-                    savings_exact=False,
-                    command=f"mailtrim purge --domain {domain} --older-than 30",
+            elif days >= 90:
+                # Old clutter — only suggest the 90d age action when emails that old exist
+                actions.append(
+                    Action(
+                        label="Delete older than 90d",
+                        savings_mb=round(size_mb * 0.85, 1),
+                        savings_exact=False,
+                        command=f"mailtrim purge --domain {domain} --older-than 90",
+                    )
                 )
-            )
+
+            if size_mb < 1 and days >= 30:
+                # Too small for size-based actions; only useful as noise cleanup
+                actions.append(
+                    Action(
+                        label="Delete older than 30d",
+                        savings_mb=round(size_mb * 0.8, 1),
+                        savings_exact=False,
+                        command=f"mailtrim purge --domain {domain} --older-than 30",
+                    )
+                )
+
+        # Skip senders with no actionable steps — nothing useful to show
+        if not actions:
+            continue
 
         recs.append(
             Recommendation(
@@ -696,6 +897,13 @@ def generate_recommendations(
             )
         )
 
+    # Sort: safe/review-class senders first, sensitive last.
+    # Within each tier, preserve the confidence-weighted impact ranking.
+    def _rec_tier(r: Recommendation) -> int:
+        rc = classify_sender_risk(r.sender)
+        return 0 if rc == "safe" else 1 if rc == "review" else 2
+
+    recs.sort(key=_rec_tier)
     return recs
 
 
@@ -711,17 +919,63 @@ def reclaimable_mb(recs: list[Recommendation]) -> float:
     return round(sum(rec.actions[0].savings_mb for rec in recs if rec.actions), 1)
 
 
+def best_next_step(recs: list[Recommendation]) -> Recommendation | None:
+    """
+    Easiest, safest first move for a first-time user.
+
+    Strict priority tiers — a lower tier is only used when the higher tier
+    is completely empty:
+
+      Tier 1 — Safe to clean (green): rank by confidence, then impact, then count.
+      Tier 2 — Needs review (yellow): rank by confidence, then impact.
+      Tier 3 — Sensitive (red): last resort, rank by confidence only.
+
+    This guarantees BEST NEXT STEP always points at the most trustworthy item,
+    never at a bank or school when a newsletter exists.
+    """
+    valid = [r for r in recs if r.actions]
+    if not valid:
+        return None
+
+    def _by_conf_impact_count(r: Recommendation) -> tuple:
+        return (r.confidence, r.sender.impact_score, r.sender.count)
+
+    def _by_conf_impact(r: Recommendation) -> tuple:
+        return (r.confidence, r.sender.impact_score)
+
+    safe_pool = [r for r in valid if classify_sender_risk(r.sender) == "safe"]
+    if safe_pool:
+        return max(safe_pool, key=_by_conf_impact_count)
+
+    review_pool = [r for r in valid if classify_sender_risk(r.sender) == "review"]
+    if review_pool:
+        return max(review_pool, key=_by_conf_impact)
+
+    return max(valid, key=lambda r: r.confidence)
+
+
 def quick_win(recs: list[Recommendation]) -> Recommendation | None:
     """
-    The single recommendation most worth doing first.
+    Best combination of size, confidence, and safety.
 
-    Composite score: 60% confidence + 40% impact.
-    Confidence is weighted higher so the "quick win" feels safe to act on
-    immediately, not just impactful.
+    Composite score = savings_mb * 0.5 + confidence * 0.3 + safety_bonus * 0.2
+    where safety_bonus is 100 for non-sensitive, 0 for sensitive senders.
+
+    Sensitive senders are only chosen when no non-sensitive alternative exists.
+    Requires confidence >= 40 so the result is not a dangerous pick.
     """
-    if not recs:
+    valid = [r for r in recs if r.actions and r.confidence >= 40]
+    if not valid:
         return None
-    return max(recs, key=lambda r: r.confidence * 0.6 + r.sender.impact_score * 0.4)
+
+    def _score(r: Recommendation) -> float:
+        savings = r.actions[0].savings_mb if r.actions else 0
+        rc = classify_sender_risk(r.sender)
+        # safe=100, review=50, sensitive=0 — biases toward visible safe wins
+        safety_bonus = 100 if rc == "safe" else 50 if rc == "review" else 0
+        return savings * 0.4 + r.confidence * 0.3 + safety_bonus * 0.3
+
+    return max(valid, key=_score)
 
 
 # ── Fetch + pipeline ─────────────────────────────────────────────────────────

--- a/mailtrim/core/sender_stats.py
+++ b/mailtrim/core/sender_stats.py
@@ -15,9 +15,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from mailtrim.config import get_settings
+
+if TYPE_CHECKING:
+    from mailtrim.core.providers.base import EmailProvider
 from mailtrim.core.gmail_client import GmailClient, Message
 
 SortKey = Literal["score", "count", "oldest", "size"]
@@ -725,7 +728,7 @@ def quick_win(recs: list[Recommendation]) -> Recommendation | None:
 
 
 def fetch_sender_groups(
-    client: GmailClient,
+    client: "GmailClient | EmailProvider",
     query: str = "category:promotions OR label:newsletters",
     max_messages: int = 2000,
     min_count: int = 2,
@@ -814,23 +817,24 @@ class _Accumulator:
         )
 
 
-def _fetch_metadata_batch(client: GmailClient, ids: list[str]) -> list[Message]:
+def _fetch_metadata_batch(client: "GmailClient | EmailProvider", ids: list[str]) -> list[Message]:
     """
     Fetch message metadata in batches.
-    Uses client._fetch_batch() which correctly avoids the closure-over-loop-variable bug.
+
+    Delegates to client.get_messages_metadata() so both GmailClient (legacy)
+    and EmailProvider implementations (Gmail, IMAP) work transparently.
+    GmailClient exposes get_messages_metadata via GmailProvider; callers that
+    still pass a raw GmailClient fall back to the private _fetch_batch path.
     """
+    # EmailProvider path (GmailProvider, IMAPProvider)
+    if hasattr(client, "get_messages_metadata"):
+        return client.get_messages_metadata(ids)
+
+    # Legacy GmailClient path — keep working without any changes to call sites
     settings = get_settings()
     results: list[Message] = []
-
     from mailtrim.core.gmail_client import _chunks
 
     for chunk in _chunks(ids, settings.gmail_batch_size):
-        # Delegate to the client's tested batch helper rather than duplicating the pattern
-        batch_msgs = client._fetch_batch(
-            chunk,
-            format="metadata",
-            # metadata headers are set inside _fetch_batch via the service call
-        )
-        results.extend(batch_msgs)
-
+        results.extend(client._fetch_batch(chunk, format="metadata"))
     return results

--- a/mailtrim/core/sender_stats.py
+++ b/mailtrim/core/sender_stats.py
@@ -581,9 +581,17 @@ class Recommendation:
     confidence: int = 0  # 0–100; how safe this deletion is
 
 
-def generate_recommendations(groups: list[SenderGroup], top_n: int = 3) -> list[Recommendation]:
+def generate_recommendations(
+    groups: list[SenderGroup],
+    top_n: int = 3,
+    domain_map: dict[str, DomainGroup] | None = None,
+) -> list[Recommendation]:
     """
     For the top N senders by impact score, produce up to 2 concrete actions each.
+
+    domain_map: optional {domain: DomainGroup} used so that count/size thresholds
+    and savings figures reflect the full domain scope that ``purge --domain`` targets,
+    not just the single sender address that stats grouped by.
 
     Decision logic (determines which actions are shown):
     - High-size sender    → Delete all (exact savings) + Delete older than 90d
@@ -602,10 +610,14 @@ def generate_recommendations(groups: list[SenderGroup], top_n: int = 3) -> list[
 
     for g in by_score[:top_n]:
         actions: list[Action] = []
-        size_mb = g.total_size_mb
-        count = g.count
         domain = g.domain
-        days = g.inbox_days
+
+        # Use domain-level totals when available so savings and thresholds
+        # match what `purge --domain` will actually delete.
+        d = domain_map.get(domain) if domain_map else None
+        size_mb = d.total_size_mb if d else g.total_size_mb
+        count = d.count if d else g.count
+        days = g.inbox_days  # sender-level age is the right signal here
 
         # Action 1: always offer "delete all" if there's meaningful size
         if size_mb >= 1:

--- a/mailtrim/core/usage_stats.py
+++ b/mailtrim/core/usage_stats.py
@@ -1,0 +1,100 @@
+"""
+Local-only usage metrics — never uploaded anywhere.
+
+Tracks command runs, emails trashed, undo count, and first run date.
+Used only to understand how mailtrim is being used locally and to inform
+future product decisions.
+
+Data is stored in ~/.mailtrim/usage.json  (plain JSON, human-readable).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+
+from mailtrim.config import DATA_DIR
+
+logger = logging.getLogger(__name__)
+
+_STATS_PATH = DATA_DIR / "usage.json"
+
+_DEFAULT: dict = {
+    "first_run": None,  # ISO date string
+    "total_runs": 0,
+    "command_counts": {},  # {"stats": 12, "purge": 3, ...}
+    "emails_trashed": 0,
+    "emails_restored": 0,
+    "undo_count": 0,
+    "version_first_seen": {},  # {"0.2.0": "2026-04-11"}
+}
+
+
+def _load() -> dict:
+    try:
+        if _STATS_PATH.exists():
+            return json.loads(_STATS_PATH.read_text())
+    except Exception as exc:
+        logger.debug("Could not load usage stats: %s", exc)
+    return dict(_DEFAULT)
+
+
+def _save(data: dict) -> None:
+    try:
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        _STATS_PATH.write_text(json.dumps(data, indent=2))
+    except Exception as exc:
+        logger.debug("Could not save usage stats: %s", exc)
+
+
+def record_run(command: str) -> None:
+    """Record that a command was run. Called at the start of each command."""
+    from mailtrim import __version__
+
+    data = _load()
+    now = datetime.now(timezone.utc).date().isoformat()
+
+    if data.get("first_run") is None:
+        data["first_run"] = now
+
+    data["total_runs"] = data.get("total_runs", 0) + 1
+    counts = data.get("command_counts", {})
+    counts[command] = counts.get(command, 0) + 1
+    data["command_counts"] = counts
+
+    versions = data.get("version_first_seen", {})
+    if __version__ not in versions:
+        versions[__version__] = now
+    data["version_first_seen"] = versions
+
+    _save(data)
+
+
+def record_emails_trashed(count: int) -> None:
+    """Record how many emails were moved to Trash."""
+    data = _load()
+    data["emails_trashed"] = data.get("emails_trashed", 0) + count
+    _save(data)
+
+
+def record_undo(restored: int = 0) -> None:
+    """Record an undo operation."""
+    data = _load()
+    data["undo_count"] = data.get("undo_count", 0) + 1
+    data["emails_restored"] = data.get("emails_restored", 0) + restored
+    _save(data)
+
+
+def get_stats() -> dict:
+    """Return current usage stats as a plain dict."""
+    return _load()
+
+
+def format_summary() -> str:
+    """Return a single human-readable summary line."""
+    data = _load()
+    trashed = data.get("emails_trashed", 0)
+    runs = data.get("total_runs", 0)
+    first = data.get("first_run", "unknown")
+    return f"{trashed:,} emails trashed across {runs} runs since {first}"

--- a/mailtrim/core/validation.py
+++ b/mailtrim/core/validation.py
@@ -1,0 +1,92 @@
+"""
+Input validation helpers — centralise all user-supplied value checks.
+
+Every value that flows from the CLI into a Gmail API query or file path goes
+through one of these validators before use.  Validators raise ``typer.BadParameter``
+so errors surface as friendly CLI messages rather than raw exceptions.
+"""
+
+from __future__ import annotations
+
+import re
+
+import typer
+
+# ── Domain names ──────────────────────────────────────────────────────────────
+# RFC 1123 label: starts/ends with alnum, hyphens allowed in the middle.
+# We also allow leading wildcard (*.) for informational display, but strip it
+# before embedding in queries.
+_LABEL = r"[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?"
+_DOMAIN_RE = re.compile(rf"^({_LABEL}\.)+{_LABEL}$")
+
+
+def validate_domain(value: str) -> str:
+    """
+    Ensure *value* is a well-formed domain name before embedding it in a Gmail
+    query (prevents query injection via crafted domain strings).
+
+    Accepts: ``example.com``, ``mail.example.co.uk``
+    Rejects: ``example.com OR from:other@bad.com``, ``-in:inbox``, ``../../..``
+
+    Returns the lowercased domain on success.
+    Raises typer.BadParameter on failure.
+    """
+    cleaned = value.strip().lower()
+    if not _DOMAIN_RE.match(cleaned):
+        raise typer.BadParameter(
+            f"'{value}' is not a valid domain name. "
+            "Expected format: example.com or mail.example.com"
+        )
+    return cleaned
+
+
+# ── Email addresses ───────────────────────────────────────────────────────────
+# Deliberately simple — the Gmail API validates the actual deliverability.
+# We only need to block obvious injection strings (spaces, query operators).
+_EMAIL_RE = re.compile(r"^[^@\s]{1,64}@[^@\s]{1,255}$")
+
+
+def validate_sender_email(value: str) -> str:
+    """
+    Ensure *value* looks like an email address before embedding it in a Gmail
+    ``from:`` query.
+
+    Accepts: ``user@example.com``
+    Rejects: strings with spaces, multiple @, or Gmail query operators.
+
+    Returns the lowercased address on success.
+    Raises typer.BadParameter on failure.
+    """
+    cleaned = value.strip().lower()
+    if not _EMAIL_RE.match(cleaned):
+        raise typer.BadParameter(
+            f"'{value}' is not a valid email address. Expected format: user@example.com"
+        )
+    return cleaned
+
+
+# ── Numeric bounds ────────────────────────────────────────────────────────────
+
+_MAX_OLDER_THAN_DAYS = 36_500  # 100 years — anything beyond this is meaningless
+
+
+def validate_older_than(days: int) -> int:
+    """
+    Ensure the ``--older-than`` value is a sensible positive integer.
+
+    Gmail silently ignores ``older_than:0d`` and ``older_than:-1d``, which
+    produces confusing results.  An absurdly large value (> 100 years) almost
+    certainly indicates a mistake.
+
+    Returns the validated int on success.
+    Raises typer.BadParameter on failure.
+    """
+    if days <= 0:
+        raise typer.BadParameter(
+            f"--older-than must be a positive number of days (got {days})."
+        )
+    if days > _MAX_OLDER_THAN_DAYS:
+        raise typer.BadParameter(
+            f"--older-than value {days} exceeds 100 years — did you mean something else?"
+        )
+    return days

--- a/mailtrim/core/validation.py
+++ b/mailtrim/core/validation.py
@@ -82,9 +82,7 @@ def validate_older_than(days: int) -> int:
     Raises typer.BadParameter on failure.
     """
     if days <= 0:
-        raise typer.BadParameter(
-            f"--older-than must be a positive number of days (got {days})."
-        )
+        raise typer.BadParameter(f"--older-than must be a positive number of days (got {days}).")
     if days > _MAX_OLDER_THAN_DAYS:
         raise typer.BadParameter(
             f"--older-than value {days} exceeds 100 years — did you mean something else?"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,255 @@
+"""Tests for the doctor command diagnostics and error message translation."""
+
+from __future__ import annotations
+
+# ── CheckResult dataclass ────────────────────────────────────────────────────
+
+
+def test_check_result_fields():
+    from mailtrim.core.diagnostics import CheckResult
+
+    r = CheckResult(name="Test", ok=True, message="All good")
+    assert r.ok is True
+    assert r.fix == ""
+    assert r.optional is False
+
+
+def test_check_result_failure_with_fix():
+    from mailtrim.core.diagnostics import CheckResult
+
+    r = CheckResult(name="Auth", ok=False, message="Token missing", fix="mailtrim auth")
+    assert r.ok is False
+    assert "mailtrim auth" in r.fix
+
+
+def test_check_result_optional():
+    from mailtrim.core.diagnostics import CheckResult
+
+    r = CheckResult(name="AI", ok=False, message="Not reachable", optional=True)
+    assert r.optional is True
+
+
+# ── Token checks ─────────────────────────────────────────────────────────────
+
+
+def test_check_token_exists_missing(tmp_path, monkeypatch):
+    """Returns failure when TOKEN_PATH does not exist."""
+    monkeypatch.setattr("mailtrim.config.TOKEN_PATH", tmp_path / "token.json")
+    import importlib
+
+    import mailtrim.core.diagnostics as diag
+
+    importlib.reload(diag)
+    result = diag.check_token_exists()
+    assert result.ok is False
+    assert "mailtrim auth" in result.fix
+
+
+def test_check_token_exists_present(tmp_path, monkeypatch):
+    token = tmp_path / "token.json"
+    token.write_text("{}")
+    monkeypatch.setattr("mailtrim.config.TOKEN_PATH", token)
+    import importlib
+
+    import mailtrim.core.diagnostics as diag
+
+    importlib.reload(diag)
+    result = diag.check_token_exists()
+    assert result.ok is True
+
+
+# ── Data dir / config checks ─────────────────────────────────────────────────
+
+
+def test_check_data_dir_writable(tmp_path, monkeypatch):
+    monkeypatch.setattr("mailtrim.config.DATA_DIR", tmp_path)
+    import importlib
+
+    import mailtrim.core.diagnostics as diag
+
+    importlib.reload(diag)
+    result = diag.check_data_dir()
+    assert result.ok is True
+
+
+def test_check_data_dir_unwritable(tmp_path, monkeypatch):
+    """Simulate unwritable directory by making it read-only."""
+    import os
+
+    ro_dir = tmp_path / "ro"
+    ro_dir.mkdir()
+    os.chmod(ro_dir, 0o444)
+    monkeypatch.setattr("mailtrim.config.DATA_DIR", ro_dir)
+    import importlib
+
+    import mailtrim.core.diagnostics as diag
+
+    importlib.reload(diag)
+    result = diag.check_data_dir()
+    # restore permissions so tmp cleanup works
+    os.chmod(ro_dir, 0o755)
+    assert result.ok is False
+    assert result.fix != ""
+
+
+# ── Dependencies check ────────────────────────────────────────────────────────
+
+
+def test_check_dependencies_all_present():
+    from mailtrim.core.diagnostics import check_dependencies
+
+    result = check_dependencies()
+    assert result.ok is True
+    assert "All required" in result.message
+
+
+# ── AI endpoint check ─────────────────────────────────────────────────────────
+
+
+def test_check_ai_endpoint_unreachable():
+    from mailtrim.core.diagnostics import check_ai_endpoint
+
+    result = check_ai_endpoint(url="http://127.0.0.1:19999")  # unused port
+    assert result.ok is False
+    assert result.optional is True
+
+
+# ── run_all ───────────────────────────────────────────────────────────────────
+
+
+def test_run_all_returns_list():
+    from mailtrim.core.diagnostics import run_all
+
+    results = run_all(include_optional=False)
+    assert isinstance(results, list)
+    assert len(results) > 0
+    for r in results:
+        assert hasattr(r, "ok")
+        assert hasattr(r, "name")
+
+
+def test_run_all_optional_included():
+    from mailtrim.core.diagnostics import run_all
+
+    with_opt = run_all(include_optional=True)
+    without_opt = run_all(include_optional=False)
+    assert len(with_opt) >= len(without_opt)
+
+
+# ── friendly_error ────────────────────────────────────────────────────────────
+
+
+def test_friendly_error_invalid_grant():
+    from mailtrim.core.errors import friendly_error
+
+    exc = Exception("invalid_grant: Token has been expired or revoked.")
+    msg, fix = friendly_error(exc)
+    assert "expired" in msg.lower()
+    assert "mailtrim auth" in fix
+
+
+def test_friendly_error_timeout():
+    from mailtrim.core.errors import friendly_error
+
+    exc = Exception("Connection timed out trying to reach Gmail API")
+    msg, fix = friendly_error(exc)
+    assert "internet" in msg.lower() or "reach" in msg.lower()
+
+
+def test_friendly_error_permission_denied():
+    from mailtrim.core.errors import friendly_error
+
+    exc = PermissionError("Permission denied: '/Users/x/.mailtrim/token.json'")
+    msg, fix = friendly_error(exc)
+    assert "permission" in msg.lower() or "write" in msg.lower()
+    assert "~/.mailtrim" in fix
+
+
+def test_friendly_error_credentials_missing():
+    from mailtrim.core.errors import friendly_error
+
+    exc = FileNotFoundError("OAuth credentials file not found at /path/credentials.json.")
+    msg, fix = friendly_error(exc)
+    assert "not found" in msg.lower() or "credential" in msg.lower()
+
+
+def test_friendly_error_rate_limit():
+    from mailtrim.core.errors import friendly_error
+
+    exc = Exception("HttpError 429 when requesting... rateLimitExceeded")
+    msg, fix = friendly_error(exc)
+    assert "rate limit" in msg.lower()
+    assert "60 seconds" in fix or "wait" in fix.lower()
+
+
+def test_friendly_error_403():
+    from mailtrim.core.errors import friendly_error
+
+    exc = Exception("HttpError 403 when requesting... 403")
+    msg, fix = friendly_error(exc)
+    assert "denied" in msg.lower() or "permission" in msg.lower()
+
+
+def test_friendly_error_database_corrupt():
+    from mailtrim.core.errors import friendly_error
+
+    exc = Exception("disk image is malformed")
+    msg, fix = friendly_error(exc)
+    assert "corrupt" in msg.lower() or "database" in msg.lower()
+    assert "mailtrim.db" in fix
+
+
+def test_friendly_error_unknown_falls_back():
+    from mailtrim.core.errors import friendly_error
+
+    exc = RuntimeError("something completely unexpected happened xyz123")
+    msg, fix = friendly_error(exc)
+    assert "xyz123" in msg or "unexpected" in msg.lower()
+    assert "github" in fix
+
+
+# ── usage stats ───────────────────────────────────────────────────────────────
+
+
+def test_usage_stats_record_run(tmp_path, monkeypatch):
+    monkeypatch.setattr("mailtrim.core.usage_stats._STATS_PATH", tmp_path / "usage.json")
+    from mailtrim.core.usage_stats import get_stats, record_run
+
+    record_run("stats")
+    record_run("stats")
+    record_run("purge")
+    data = get_stats()
+    assert data["command_counts"]["stats"] == 2
+    assert data["command_counts"]["purge"] == 1
+    assert data["total_runs"] == 3
+    assert data["first_run"] is not None
+
+
+def test_usage_stats_emails_trashed(tmp_path, monkeypatch):
+    monkeypatch.setattr("mailtrim.core.usage_stats._STATS_PATH", tmp_path / "usage.json")
+    from mailtrim.core.usage_stats import get_stats, record_emails_trashed
+
+    record_emails_trashed(50)
+    record_emails_trashed(25)
+    assert get_stats()["emails_trashed"] == 75
+
+
+def test_usage_stats_undo(tmp_path, monkeypatch):
+    monkeypatch.setattr("mailtrim.core.usage_stats._STATS_PATH", tmp_path / "usage.json")
+    from mailtrim.core.usage_stats import get_stats, record_undo
+
+    record_undo(restored=30)
+    data = get_stats()
+    assert data["undo_count"] == 1
+    assert data["emails_restored"] == 30
+
+
+def test_usage_stats_format_summary(tmp_path, monkeypatch):
+    monkeypatch.setattr("mailtrim.core.usage_stats._STATS_PATH", tmp_path / "usage.json")
+    from mailtrim.core.usage_stats import format_summary, record_emails_trashed, record_run
+
+    record_run("purge")
+    record_emails_trashed(100)
+    summary = format_summary()
+    assert "100" in summary
+    assert "1 run" in summary or "runs" in summary

--- a/tests/test_purge.py
+++ b/tests/test_purge.py
@@ -486,15 +486,15 @@ def test_confidence_safety_label_high():
 def test_confidence_safety_label_medium():
     from mailtrim.core.sender_stats import confidence_safety_label
 
-    assert confidence_safety_label(40) == "Low risk"
-    assert confidence_safety_label(69) == "Low risk"
+    assert confidence_safety_label(40) == "Needs review"
+    assert confidence_safety_label(69) == "Needs review"
 
 
 def test_confidence_safety_label_low():
     from mailtrim.core.sender_stats import confidence_safety_label
 
-    assert confidence_safety_label(0) == "Review first"
-    assert confidence_safety_label(39) == "Review first"
+    assert confidence_safety_label(0) == "Sensitive / personal"
+    assert confidence_safety_label(39) == "Sensitive / personal"
 
 
 # ── impact_label ─────────────────────────────────────────────────────────────

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,124 @@
+"""Tests for the input validation module (mailtrim.core.validation)."""
+
+import pytest
+import typer
+
+from mailtrim.core.validation import validate_domain, validate_older_than, validate_sender_email
+
+
+# ── validate_domain ───────────────────────────────────────────────────────────
+
+class TestValidateDomain:
+    def test_simple_domain(self):
+        assert validate_domain("example.com") == "example.com"
+
+    def test_subdomain(self):
+        assert validate_domain("mail.example.com") == "mail.example.com"
+
+    def test_deep_subdomain(self):
+        assert validate_domain("a.b.c.example.co.uk") == "a.b.c.example.co.uk"
+
+    def test_normalises_to_lowercase(self):
+        assert validate_domain("LinkedIn.COM") == "linkedin.com"
+
+    def test_strips_whitespace(self):
+        assert validate_domain("  example.com  ") == "example.com"
+
+    def test_hyphen_allowed_in_label(self):
+        assert validate_domain("my-company.example.com") == "my-company.example.com"
+
+    # ── rejection cases (query injection vectors) ────────────────────────────
+
+    def test_rejects_query_injection_or(self):
+        with pytest.raises(typer.BadParameter):
+            validate_domain("evil.com OR from:other@bad.com")
+
+    def test_rejects_query_injection_space(self):
+        with pytest.raises(typer.BadParameter):
+            validate_domain("linkedin.com -in:inbox")
+
+    def test_rejects_bare_label_no_dot(self):
+        """Single-label 'domains' are not valid FQDNs."""
+        with pytest.raises(typer.BadParameter):
+            validate_domain("localhost")
+
+    def test_rejects_leading_hyphen(self):
+        with pytest.raises(typer.BadParameter):
+            validate_domain("-evil.com")
+
+    def test_rejects_trailing_hyphen(self):
+        with pytest.raises(typer.BadParameter):
+            validate_domain("evil-.com")
+
+    def test_rejects_path_traversal(self):
+        with pytest.raises(typer.BadParameter):
+            validate_domain("../../etc/passwd")
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(typer.BadParameter):
+            validate_domain("")
+
+    def test_rejects_at_sign(self):
+        with pytest.raises(typer.BadParameter):
+            validate_domain("user@example.com")
+
+    def test_rejects_parentheses(self):
+        with pytest.raises(typer.BadParameter):
+            validate_domain("(example.com)")
+
+
+# ── validate_sender_email ─────────────────────────────────────────────────────
+
+class TestValidateSenderEmail:
+    def test_valid_email(self):
+        assert validate_sender_email("user@example.com") == "user@example.com"
+
+    def test_normalises_lowercase(self):
+        assert validate_sender_email("User@EXAMPLE.COM") == "user@example.com"
+
+    def test_strips_whitespace(self):
+        assert validate_sender_email("  user@example.com  ") == "user@example.com"
+
+    def test_rejects_no_at(self):
+        with pytest.raises(typer.BadParameter):
+            validate_sender_email("notanemail")
+
+    def test_rejects_space_in_address(self):
+        with pytest.raises(typer.BadParameter):
+            validate_sender_email("user @example.com")
+
+    def test_rejects_multiple_at(self):
+        with pytest.raises(typer.BadParameter):
+            validate_sender_email("user@@example.com")
+
+    def test_rejects_injection_suffix(self):
+        with pytest.raises(typer.BadParameter):
+            validate_sender_email("user@evil.com OR from:other@bad.com")
+
+
+# ── validate_older_than ───────────────────────────────────────────────────────
+
+class TestValidateOlderThan:
+    def test_valid_positive(self):
+        assert validate_older_than(30) == 30
+
+    def test_valid_one(self):
+        assert validate_older_than(1) == 1
+
+    def test_valid_large(self):
+        assert validate_older_than(365) == 365
+
+    def test_rejects_zero(self):
+        with pytest.raises(typer.BadParameter):
+            validate_older_than(0)
+
+    def test_rejects_negative(self):
+        with pytest.raises(typer.BadParameter):
+            validate_older_than(-5)
+
+    def test_rejects_over_100_years(self):
+        with pytest.raises(typer.BadParameter):
+            validate_older_than(36_501)
+
+    def test_boundary_max_allowed(self):
+        assert validate_older_than(36_500) == 36_500

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,8 +5,8 @@ import typer
 
 from mailtrim.core.validation import validate_domain, validate_older_than, validate_sender_email
 
-
 # ── validate_domain ───────────────────────────────────────────────────────────
+
 
 class TestValidateDomain:
     def test_simple_domain(self):
@@ -69,6 +69,7 @@ class TestValidateDomain:
 
 # ── validate_sender_email ─────────────────────────────────────────────────────
 
+
 class TestValidateSenderEmail:
     def test_valid_email(self):
         assert validate_sender_email("user@example.com") == "user@example.com"
@@ -97,6 +98,7 @@ class TestValidateSenderEmail:
 
 
 # ── validate_older_than ───────────────────────────────────────────────────────
+
 
 class TestValidateOlderThan:
     def test_valid_positive(self):


### PR DESCRIPTION
## Summary

Closes #17 (IMAP support) · Closes #24 (Ollama backend)

This PR delivers two originally scoped features plus a set of DX improvements that naturally fell out of the work:

### Provider abstraction (email backends)
- `EmailProvider` ABC with 8-method interface — list, fetch-batch, fetch-metadata, trash, delete, archive, label, profile
- `GmailProvider` wraps the existing client unchanged
- `IMAPProvider` — full stdlib-only implementation (`imaplib`), SSL-only, batch fetch (100 UIDs/round-trip), metadata-first strategy; zero new pip dependencies
- `factory.get_provider("gmail"|"imap", ...)` — the only place that imports concrete providers; all pipeline code depends solely on the interface

### AI backend abstraction
- `AIClient` ABC + `LlamaCppClient` + `OllamaClient` — both fail silently in ≤2s so offline machines see no slowdown
- `LlamaCppClient` sends a GBNF grammar to constrain model output to the S:/C:/A: format the parser already expects
- `llm.py` wired to use `AIClient`; scoring, ranking, and output logic untouched

### Smarter sender risk classification
- Three risk tiers: `sensitive` (bank/healthcare/legal/gov — never auto-delete), `safe` (confirmed newsletter/promo), `review` (everything else)
- `should_analyze()` now always runs AI on top recommended senders and finance keywords; threshold raised 70→80 so borderline cases get AI validation
- Label renames: "Low risk" → "Needs review", "Review first" → "Sensitive / personal"

### DX: doctor, quickstart, and friendly errors
- `mailtrim doctor` — 8 independent checks (auth token, Gmail connection, credentials, config dir, permissions, quota, local AI endpoint, writable data dir), each with a one-line fix hint
- `mailtrim quickstart` — guided first-run: auth → doctor → stats
- `core/errors.py` — `friendly_error(exc)` maps the most common failures to human messages + fix hints; raw tracebacks hidden unless `--verbose`
- `core/usage_stats.py` — local-only metrics in `~/.mailtrim/usage.json`; never uploaded

### Security hardening
- Input validation layer (`core/validation.py`)
- File permission checks on credentials/token
- `gmail_client.py` hardened

## Test plan

- [ ] `pytest tests/` passes
- [ ] `mailtrim doctor` shows all green on a configured machine
- [ ] `mailtrim stats` and `mailtrim purge` unchanged for Gmail users (no regression)
- [ ] IMAP: `mailtrim stats --provider imap --imap-server imap.example.com --imap-user user@example.com --imap-password <app-password>` fetches and scores senders
- [ ] Ollama: `mailtrim stats --ai-backend ollama` uses local model when Ollama is running; falls back gracefully when it isn't
- [ ] Bank/healthcare senders show 🔴 "Sensitive / personal" in all panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)