### PR TITLE
fix: bump pyproject.toml to 0.2.1 (PyPI publish was building 0.1.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mailtrim"
-version = "0.1.0"
+version = "0.2.1"
 description = "Privacy-first Gmail inbox management — local-first core, optional AI via Anthropic API"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- `__init__.py` was bumped to `0.2.1` in #28 but `pyproject.toml` was missed
- The publish workflow built `mailtrim-0.1.0.whl` and hit a 400 from PyPI ("File already exists")
- This is a one-line fix; after merging, delete the `v0.2.1` tag and re-push it to retrigger the publish workflow

## After merging

```bash
git tag -d v0.2.1
git push origin :refs/tags/v0.2.1
git checkout main && git pull
git tag v0.2.1 && git push origin v0.2.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)