### PR TITLE
chore: bump to v0.2.2

### DIFF
--- a/mailtrim/__init__.py
+++ b/mailtrim/__init__.py
@@ -1,3 +1,3 @@
 """mailtrim: Privacy-first, AI-powered Gmail inbox management."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mailtrim"
-version = "0.2.1"
+version = "0.2.2"
 description = "Privacy-first Gmail inbox management — local-first core, optional AI via Anthropic API"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

`0.2.1` was already published to PyPI before the doctor fix (PR #31) landed, so the publish workflow failed with "File already exists". PyPI never allows overwriting a published filename.

Bumping to `0.2.2` to ship the doctor fix cleanly.

## After merging

```bash
git checkout main && git pull
git tag v0.2.2 && git push origin v0.2.2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)