### PR TITLE
feat: privacy-safe AI mode system (off/local/cloud)

### DIFF
--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -790,16 +790,19 @@ def stats(
                 )
             ai_insights[rec.sender.sender_email] = result
 
-        if ai_insights:
+        if any(ai_insights.values()):
             from mailtrim.core.llm import apply_impact_nudge
 
             apply_impact_nudge(groups, ai_insights)
         else:
+            _expected = ai_url or (
+                "http://localhost:11434" if ai_backend == "ollama" else "http://localhost:8080"
+            )
             console.print(
-                "[yellow]⚠ Local AI unavailable[/yellow] — results shown without AI enrichment.\n"
-                f"  Is {'Ollama' if ai_backend == 'ollama' else 'llama.cpp'} running? "
-                f"Expected at {ai_url or ('http://localhost:11434' if ai_backend == 'ollama' else 'http://localhost:8080')}\n"
-                "  [dim]Results are still accurate — AI only adjusts confidence scores.[/dim]"
+                f"\n[yellow]⚠ Local AI unavailable[/yellow] — results shown without AI enrichment.\n"
+                f"  Is [bold]{'Ollama' if ai_backend == 'ollama' else 'llama.cpp'}[/bold] running?"
+                f" Expected at {_expected}\n"
+                "  [dim]Results are still accurate — AI only adjusts confidence scores.[/dim]\n"
             )
 
     if recommendations:
@@ -2201,15 +2204,18 @@ def purge(
                 ai_results = analyze_batch(texts, cache_keys=keys, ai_client=_purge_ai_client)
             purge_ai_insights = {g.sender_email: r for g, r in zip(eligible_groups, ai_results)}
 
-        if purge_ai_insights:
+        if any(purge_ai_insights.values()):
             from mailtrim.core.llm import apply_impact_nudge
 
             apply_impact_nudge(groups, purge_ai_insights)
         elif eligible_groups:
+            _expected = ai_url or (
+                "http://localhost:11434" if ai_backend == "ollama" else "http://localhost:8080"
+            )
             console.print(
-                "[yellow]⚠ Local AI unavailable[/yellow] — confidence scores not adjusted.\n"
-                f"  Is {'Ollama' if ai_backend == 'ollama' else 'llama.cpp'} running? "
-                f"Expected at {ai_url or ('http://localhost:11434' if ai_backend == 'ollama' else 'http://localhost:8080')}"
+                f"\n[yellow]⚠ Local AI unavailable[/yellow] — confidence scores not adjusted.\n"
+                f"  Is [bold]{'Ollama' if ai_backend == 'ollama' else 'llama.cpp'}[/bold] running?"
+                f" Expected at {_expected}\n"
             )
 
     console.print()

--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -118,7 +118,12 @@ def _is_first_stats_run() -> bool:
 
 def _handle_error(exc: Exception, verbose: bool = False) -> None:
     """Translate an exception to a friendly message and exit."""
+    from mailtrim.core.ai.mode import AIModeError
     from mailtrim.core.errors import friendly_error
+
+    if isinstance(exc, AIModeError):
+        console.print(f"\n[yellow]AI blocked:[/yellow] {exc}")
+        raise typer.Exit(1)
 
     human_msg, fix_hint = friendly_error(exc)
     console.print(f"\n[red]Error:[/red] {human_msg}")
@@ -731,6 +736,9 @@ def stats(
     # Optional local-AI enrichment — always runs on all top recommendations.
     ai_insights: dict[str, dict] = {}
     if use_ai and recommendations:
+        from mailtrim.core.ai.mode import require_local
+
+        require_local(get_settings().ai_mode)
         from mailtrim.core.llm import (
             analyze_batch,
             confidence_delta,
@@ -1113,6 +1121,9 @@ def triage(
     ),
 ):
     """AI-powered inbox triage with explanations for every decision."""
+    from mailtrim.core.ai.mode import require_cloud
+
+    require_cloud(get_settings().ai_mode)
     from mailtrim.core.avoidance import AvoidanceDetector
 
     client = _get_client()
@@ -1245,8 +1256,10 @@ def bulk(
       mailtrim bulk "delete all emails from noreply@* older than 1 year"
       mailtrim bulk "label as 'receipts' everything from order confirmation senders"
     """
+    from mailtrim.core.ai.mode import require_cloud
     from mailtrim.core.bulk_engine import BulkEngine
 
+    require_cloud(get_settings().ai_mode)
     client = _get_client()
     account_email = _get_account_email(client)
     engine = BulkEngine(client, account_email, _get_ai())
@@ -1489,8 +1502,10 @@ def avoid(
     [EXPERIMENTAL] Show emails you've been putting off — viewed multiple times but never acted on.
     AI explains why you might be avoiding them and suggests one action.
     """
+    from mailtrim.core.ai.mode import require_cloud
     from mailtrim.core.avoidance import AvoidanceDetector
 
+    require_cloud(get_settings().ai_mode)
     client = _get_client()
     account_email = _get_account_email(client)
     detector = AvoidanceDetector(client, account_email, _get_ai())
@@ -1706,6 +1721,9 @@ def rules(
 @app.command()
 def digest():
     """[EXPERIMENTAL] Generate your weekly inbox digest — insights, action items, and one cleanup suggestion."""
+    from mailtrim.core.ai.mode import require_cloud
+
+    require_cloud(get_settings().ai_mode)
     from collections import Counter
 
     from mailtrim.core.avoidance import AvoidanceDetector
@@ -2151,6 +2169,9 @@ def purge(
     # Optional local-AI enrichment — only for senders where AI adds signal.
     purge_ai_insights: dict[str, dict] = {}
     if use_ai:
+        from mailtrim.core.ai.mode import require_local
+
+        require_local(get_settings().ai_mode)
         from mailtrim.core.llm import (
             analyze_batch,
             confidence_delta,
@@ -2535,6 +2556,71 @@ def doctor(
 
 
 # ── version ───────────────────────────────────────────────────────────────────
+
+
+@app.command(name="config")
+def config_cmd(
+    key: str = typer.Argument(..., help="Config key to set. Currently supported: ai-mode"),
+    value: str = typer.Argument(..., help="Value to set. For ai-mode: off | local | cloud"),
+):
+    """
+    Set a persistent configuration value.
+
+    Examples:
+      mailtrim config ai-mode off     # disable all AI (default, privacy-safe)
+      mailtrim config ai-mode local   # allow local AI only (Ollama, llama.cpp)
+      mailtrim config ai-mode cloud   # allow Anthropic cloud AI
+    """
+    if key != "ai-mode":
+        console.print(f"[red]Unknown config key '[bold]{key}[/bold]'.[/red]")
+        console.print("  Supported keys: ai-mode")
+        raise typer.Exit(1)
+
+    from mailtrim.core.ai.mode import validate_mode
+
+    try:
+        validate_mode(value)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+
+    # Persist to ~/.mailtrim/.env which Settings already reads.
+    env_path = DATA_DIR / ".env"
+    lines = env_path.read_text().splitlines() if env_path.exists() else []
+    key_line = f"MAILTRIM_AI_MODE={value}"
+    updated = [line for line in lines if not line.startswith("MAILTRIM_AI_MODE=")]
+    updated.append(key_line)
+    env_path.write_text("\n".join(updated) + "\n")
+
+    if value == "cloud":
+        console.print(
+            Panel(
+                "[green]ai_mode set to [bold]cloud[/bold][/green]\n\n"
+                "[yellow]Warning:[/yellow] Cloud AI sends email subjects and snippets\n"
+                "to Anthropic's servers. See anthropic.com/privacy for details.\n\n"
+                "Requires [bold]ANTHROPIC_API_KEY[/bold] to be set.",
+                border_style="yellow",
+            )
+        )
+    elif value == "local":
+        console.print(
+            Panel(
+                "[green]ai_mode set to [bold]local[/bold][/green]\n\n"
+                "Local AI runs entirely on your machine — nothing leaves it.\n"
+                "Requires Ollama or llama.cpp to be running.\n\n"
+                "Try:  mailtrim stats --ai",
+                border_style="green",
+            )
+        )
+    else:
+        console.print(
+            Panel(
+                "[green]ai_mode set to [bold]off[/bold][/green]\n\n"
+                "All AI features are disabled. Core commands (stats, purge, undo)\n"
+                "work fully without AI.",
+                border_style="dim",
+            )
+        )
 
 
 @app.command()

--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -794,6 +794,13 @@ def stats(
             from mailtrim.core.llm import apply_impact_nudge
 
             apply_impact_nudge(groups, ai_insights)
+        else:
+            console.print(
+                "[yellow]⚠ Local AI unavailable[/yellow] — results shown without AI enrichment.\n"
+                f"  Is {'Ollama' if ai_backend == 'ollama' else 'llama.cpp'} running? "
+                f"Expected at {ai_url or ('http://localhost:11434' if ai_backend == 'ollama' else 'http://localhost:8080')}\n"
+                "  [dim]Results are still accurate — AI only adjusts confidence scores.[/dim]"
+            )
 
     if recommendations:
         from mailtrim.core.llm import format_ai_line  # always available
@@ -2198,6 +2205,12 @@ def purge(
             from mailtrim.core.llm import apply_impact_nudge
 
             apply_impact_nudge(groups, purge_ai_insights)
+        elif eligible_groups:
+            console.print(
+                "[yellow]⚠ Local AI unavailable[/yellow] — confidence scores not adjusted.\n"
+                f"  Is {'Ollama' if ai_backend == 'ollama' else 'llama.cpp'} running? "
+                f"Expected at {ai_url or ('http://localhost:11434' if ai_backend == 'ollama' else 'http://localhost:8080')}"
+            )
 
     console.print()
     table = Table(

--- a/mailtrim/config.py
+++ b/mailtrim/config.py
@@ -42,6 +42,12 @@ class Settings(BaseSettings):
     avoidance_view_threshold: int = 3  # Views before an email is "avoided"
     follow_up_default_days: int = 3  # Default follow-up reminder window
 
+    # AI mode — controls which AI backends are permitted.
+    # "off"   → no AI calls at all (default, privacy-safe)
+    # "local" → only local backends (Ollama, llama.cpp) — nothing leaves the machine
+    # "cloud" → external API calls allowed (Anthropic); sends email data externally
+    ai_mode: str = "off"
+
     # Rate limiting
     gmail_batch_size: int = 50  # Max messages per Gmail batch request
     ai_max_classify_batch: int = 20  # Emails per AI classification call

--- a/mailtrim/core/ai/mode.py
+++ b/mailtrim/core/ai/mode.py
@@ -1,0 +1,64 @@
+"""AI mode enforcement — single place that decides whether an AI call is allowed.
+
+Three modes (set via `mailtrim config ai-mode` or MAILTRIM_AI_MODE env var):
+
+  off   → default; no AI calls whatsoever.  Privacy-safe out of the box.
+  local → only local backends (Ollama, llama.cpp).  Nothing leaves the machine.
+  cloud → external API calls permitted (Anthropic Claude).
+          Sends email subjects and snippets to Anthropic's servers.
+
+Callers must call require_local() before any local-model call and
+require_cloud() before any external API call.  Both raise AIModeError
+with actionable guidance if the current mode doesn't permit the call.
+"""
+
+from __future__ import annotations
+
+_VALID_MODES = ("off", "local", "cloud")
+
+
+class AIModeError(Exception):
+    """Raised when an AI call is blocked by the current ai_mode setting."""
+
+
+def validate_mode(mode: str) -> str:
+    """Return mode if valid, else raise ValueError."""
+    if mode not in _VALID_MODES:
+        raise ValueError(f"Invalid ai_mode '{mode}'. Valid values: {', '.join(_VALID_MODES)}")
+    return mode
+
+
+def require_local(mode: str) -> None:
+    """
+    Assert that local AI calls are permitted.
+
+    Allowed in: local, cloud
+    Blocked in: off
+    """
+    if mode == "off":
+        raise AIModeError(
+            "Local AI is disabled (ai_mode=off).\n"
+            "Enable it with:  mailtrim config ai-mode local\n"
+            "Local AI runs entirely on your machine — no data leaves it."
+        )
+
+
+def require_cloud(mode: str) -> None:
+    """
+    Assert that cloud (external) AI calls are permitted.
+
+    Allowed in: cloud
+    Blocked in: off, local
+    """
+    if mode == "off":
+        raise AIModeError(
+            "AI is disabled (ai_mode=off).\n"
+            "To use cloud AI:  mailtrim config ai-mode cloud\n"
+            "Warning: cloud mode sends email subjects and snippets to Anthropic."
+        )
+    if mode == "local":
+        raise AIModeError(
+            "Cloud AI is blocked (ai_mode=local).\n"
+            "To allow external calls:  mailtrim config ai-mode cloud\n"
+            "Warning: cloud mode sends email subjects and snippets to Anthropic."
+        )


### PR DESCRIPTION
## Summary

Adds an explicit, user-controlled AI mode gate. Default is `off` — mailtrim makes zero AI calls unless you opt in.

### New command

```bash
mailtrim config ai-mode off     # default — all AI disabled
mailtrim config ai-mode local   # local backends only (Ollama, llama.cpp)
mailtrim config ai-mode cloud   # Anthropic cloud AI — shows warning
```

Persists to `~/.mailtrim/.env` which Settings already reads.

### Mode semantics

| Mode | Local AI (`--ai`) | Cloud AI (`triage`, `bulk`, `avoid`, `digest`) |
|------|-------------------|------------------------------------------------|
| `off` | ✗ blocked | ✗ blocked |
| `local` | ✓ allowed | ✗ blocked |
| `cloud` | ✓ allowed | ✓ allowed |

### User experience

- Blocked calls print a clear `AI blocked:` message with the exact command to enable
- Cloud mode shows a warning panel: *"sends email subjects and snippets to Anthropic"*
- No silent fallback — a blocked mode always surfaces to the user

### Files changed

- `config.py` — `ai_mode: str = "off"` field added to Settings
- `core/ai/mode.py` — new enforcement module (`AIModeError`, `require_local`, `require_cloud`, `validate_mode`)
- `cli/main.py` — `config ai-mode` command + gates on `stats`, `purge`, `triage`, `bulk`, `avoid`, `digest`

**No changes** to `ai_engine.py`, `ai/client.py`, or `llm.py`.

## Test plan

- [ ] `mailtrim triage` with `ai_mode=off` → "AI blocked" message
- [ ] `mailtrim stats --ai` with `ai_mode=off` → "AI blocked" message  
- [ ] `mailtrim stats --ai` with `ai_mode=local` → proceeds
- [ ] `mailtrim triage` with `ai_mode=local` → "Cloud AI is blocked" message
- [ ] `mailtrim triage` with `ai_mode=cloud` → proceeds
- [ ] `mailtrim config ai-mode cloud` → yellow warning panel shown
- [ ] `MAILTRIM_AI_MODE=local mailtrim stats --ai` → env var respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)