### PR TITLE
feat: mailtrim privacy command

### DIFF
--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -2643,6 +2643,96 @@ def config_cmd(
 
 
 @app.command()
+def privacy():
+    """Show what data mailtrim stores and whether any leaves your machine."""
+    from mailtrim.config import (
+        CREDENTIALS_PATH,
+        DATA_DIR,
+        DB_PATH,
+        TOKEN_PATH,
+        UNDO_LOG_DIR,
+    )
+    from mailtrim.core.usage_stats import get_stats
+
+    settings = get_settings()
+    ai_mode = settings.ai_mode
+
+    # ── AI mode line ──────────────────────────────────────────────────────────
+    if ai_mode == "off":
+        ai_label = "[green]OFF[/green]"
+        ai_note = "No email data leaves your machine."
+        ai_color = "green"
+    elif ai_mode == "local":
+        ai_label = "[cyan]LOCAL[/cyan]"
+        ai_note = "Processed locally — nothing sent externally."
+        ai_color = "cyan"
+    else:  # cloud
+        ai_label = "[yellow]CLOUD[/yellow]"
+        ai_note = "May send email subjects and snippets to Anthropic."
+        ai_color = "yellow"
+
+    # ── Usage stats ───────────────────────────────────────────────────────────
+    stats = get_stats()
+    usage_enabled = (DATA_DIR / "usage.json").exists()
+    runs = stats.get("total_runs", 0)
+    trashed = stats.get("emails_trashed", 0)
+
+    console.print()
+    console.print(
+        Panel.fit(
+            "[bold]mailtrim privacy report[/bold]",
+            border_style="cyan",
+        )
+    )
+
+    console.print()
+    console.print("[bold]What is stored locally[/bold]")
+    console.print()
+
+    rows = [
+        ("OAuth token", TOKEN_PATH, "Lets mailtrim access Gmail. Never shared."),
+        ("OAuth credentials", CREDENTIALS_PATH, "Your Google Cloud app credentials. Never shared."),
+        ("Email database", DB_PATH, "Local cache of metadata (no email body stored)."),
+        ("Undo logs", UNDO_LOG_DIR, "History of cleanup operations for undo."),
+        ("Usage stats", DATA_DIR / "usage.json", "Local run counts. Never uploaded."),
+        ("Config / env", DATA_DIR / ".env", "Your settings (API keys, ai_mode, etc.)."),
+    ]
+
+    for label, path, note in rows:
+        exists = "[green]exists[/green]" if Path(path).exists() else "[dim]not created yet[/dim]"
+        console.print(f"  [bold]{label:<20}[/bold]  {exists}")
+        console.print(f"  [dim]  {path}[/dim]")
+        console.print(f"  [dim]  {note}[/dim]")
+        console.print()
+
+    console.print("[bold]AI mode[/bold]")
+    console.print()
+    console.print(f"  Current mode:  {ai_label}")
+    console.print(f"  [{ai_color}]{ai_note}[/{ai_color}]")
+    console.print()
+    console.print("  Change with:  [cyan]mailtrim config ai-mode [off|local|cloud][/cyan]")
+
+    console.print()
+    console.print("[bold]Usage stats (local only)[/bold]")
+    console.print()
+    if usage_enabled:
+        console.print(f"  [green]Enabled[/green] — stored in {DATA_DIR / 'usage.json'}")
+        console.print(f"  {runs:,} total runs · {trashed:,} emails trashed")
+        console.print("  [dim]Never uploaded. Delete the file to reset.[/dim]")
+    else:
+        console.print("  [dim]Not yet created (runs after first command).[/dim]")
+
+    console.print()
+    console.print("[bold]What never happens[/bold]")
+    console.print()
+    console.print("  [green]✓[/green]  No telemetry or analytics")
+    console.print("  [green]✓[/green]  No email body content ever stored or sent")
+    console.print("  [green]✓[/green]  No account data shared with mailtrim project")
+    console.print("  [green]✓[/green]  OAuth token stored locally at chmod 600")
+    console.print()
+
+
+@app.command()
 def version():
     """Print version."""
     console.print(f"mailtrim {__version__}")

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,0 +1,133 @@
+"""Tests for `mailtrim privacy` command output."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def reset_config(tmp_path, monkeypatch):
+    """
+    Patch config module paths and reset the Settings singleton before each test.
+    DATA_DIR and _STATS_PATH are module-level constants computed at import time,
+    so env-var monkeypatching alone is not enough — we must patch attributes directly.
+    """
+    import mailtrim.config as cfg
+    import mailtrim.core.usage_stats as us
+
+    monkeypatch.setattr(cfg, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(cfg, "DB_PATH", tmp_path / "mailtrim.db")
+    monkeypatch.setattr(cfg, "CREDENTIALS_PATH", tmp_path / "credentials.json")
+    monkeypatch.setattr(cfg, "TOKEN_PATH", tmp_path / "token.json")
+    monkeypatch.setattr(cfg, "UNDO_LOG_DIR", tmp_path / "undo_logs")
+    monkeypatch.setattr(cfg, "_settings", None)  # reset singleton
+    monkeypatch.setattr(us, "_STATS_PATH", tmp_path / "usage.json")
+
+
+def _invoke(ai_mode: str = "off"):
+    from mailtrim.cli.main import app
+
+    return runner.invoke(
+        app, ["privacy"], env={"MAILTRIM_AI_MODE": ai_mode}, catch_exceptions=False
+    )
+
+
+# ── AI mode messaging ─────────────────────────────────────────────────────────
+
+
+def test_ai_mode_off():
+    result = _invoke("off")
+    assert result.exit_code == 0
+    assert "No email data leaves your machine" in result.output
+
+
+def test_ai_mode_local():
+    result = _invoke("local")
+    assert result.exit_code == 0
+    assert "Processed locally" in result.output
+    assert "nothing sent externally" in result.output
+
+
+def test_ai_mode_cloud():
+    result = _invoke("cloud")
+    assert result.exit_code == 0
+    assert "May send email subjects" in result.output
+    assert "Anthropic" in result.output
+
+
+# ── Data locations ────────────────────────────────────────────────────────────
+
+
+def test_shows_data_dir_paths(tmp_path):
+    result = _invoke()
+    # Rich may wrap long paths across lines — join output before checking
+    flat = result.output.replace("\n", "")
+    assert str(tmp_path) in flat
+
+
+def test_shows_all_stored_items():
+    result = _invoke()
+    assert "OAuth token" in result.output
+    assert "Email database" in result.output
+    assert "Undo logs" in result.output
+    assert "Usage stats" in result.output
+    assert "Config / env" in result.output
+
+
+def test_file_exists_vs_not_created(tmp_path):
+    # token does not exist → "not created yet"
+    result = _invoke()
+    assert "not created yet" in result.output
+
+    # create token file → "exists"
+    (tmp_path / "token.json").write_text("{}")
+    result2 = _invoke()
+    assert "exists" in result2.output
+
+
+# ── Usage stats section ───────────────────────────────────────────────────────
+
+
+def test_usage_stats_not_yet_created():
+    result = _invoke()
+    assert "Not yet created" in result.output
+
+
+def test_usage_stats_shown_when_present(tmp_path):
+    (tmp_path / "usage.json").write_text(
+        json.dumps(
+            {
+                "total_runs": 7,
+                "emails_trashed": 42,
+                "first_run": "2026-05-01",
+                "command_counts": {},
+                "emails_restored": 0,
+                "undo_count": 0,
+                "version_first_seen": {},
+            }
+        )
+    )
+    result = _invoke()
+    assert result.exit_code == 0
+    assert "7" in result.output
+    assert "42" in result.output
+
+
+# ── Trust guarantees ──────────────────────────────────────────────────────────
+
+
+def test_shows_trust_guarantees():
+    result = _invoke()
+    assert "No telemetry" in result.output
+    assert "No email body" in result.output
+    assert "No account data" in result.output
+
+
+def test_shows_config_ai_mode_hint():
+    result = _invoke()
+    assert "mailtrim config ai-mode" in result.output


### PR DESCRIPTION
## Summary

- Adds `mailtrim privacy` command that shows a full local data inventory
- Displays stored files (OAuth token, credentials, DB, undo logs, usage stats, .env) with paths and exist status
- Shows current AI mode with appropriate privacy message (off/local/cloud)
- Shows usage stats (total runs + emails trashed) if usage.json exists
- Shows "What never happens" trust guarantees (no telemetry, no email body, no account data)

## Motivation

Privacy credibility is a first-class concern for mailtrim. Users should be able to audit exactly what is stored and where, without digging through source code. This command is the answer to "what does this tool actually store?".

## Test plan

- [x] 10 tests covering all sections (AI mode messaging, data paths, file exist status, usage stats, trust guarantees, config hint)
- [x] Fixture patches both `mailtrim.config` attributes and `usage_stats._STATS_PATH` to prevent module-level constant bleed-through
- [x] `python -m pytest tests/test_privacy.py -v` — 10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)