### PR TITLE
feat: mailtrim setup — guided first-time onboarding

### DIFF
--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -146,6 +146,266 @@ def _record(command: str) -> None:
         pass
 
 
+# ── setup ────────────────────────────────────────────────────────────────────
+
+
+@app.command()
+def setup():
+    """
+    Interactive first-time setup — connect your account and run your first inbox scan.
+
+    Guides you through provider selection, authentication, health checks, and
+    surfaces your first safe cleanup in ~1–2 minutes.
+    """
+    _record("setup")
+
+    from mailtrim.core.diagnostics import run_all
+    from mailtrim.core.sender_stats import (
+        best_next_step,
+        classify_sender_risk,
+        compute_confidence_score,
+        fetch_sender_groups,
+        generate_recommendations,
+        group_by_domain,
+        reclaimable_mb,
+    )
+
+    # ── Welcome ───────────────────────────────────────────────────────────────
+    console.print()
+    console.print(
+        Panel.fit(
+            "[bold cyan]Welcome to mailtrim[/bold cyan]  ·  This takes [bold]~1–2 minutes[/bold].\n"
+            "[dim]Nothing is deleted without your explicit command.[/dim]",
+            border_style="cyan",
+        )
+    )
+    console.print()
+
+    # ── Step 1: Provider selection ────────────────────────────────────────────
+    console.print("[bold]Step 1 of 3[/bold]  ·  Choose your email provider")
+    console.print()
+    console.print("  [bold]G[/bold]  Gmail via OAuth  [dim](recommended — opens browser)[/dim]")
+    console.print("  [bold]I[/bold]  IMAP  [dim](Outlook, Yahoo, custom server)[/dim]")
+    console.print()
+
+    provider_choice = Prompt.ask(
+        "  Provider", choices=["G", "g", "I", "i"], default="G", show_choices=False
+    ).upper()
+    console.print()
+
+    # ── Step 2: Authentication ────────────────────────────────────────────────
+    console.print("[bold]Step 2 of 3[/bold]  ·  Connect your account")
+    console.print()
+
+    _client = None  # set on success; used for the quickstart scan
+
+    if provider_choice == "G":
+        # Gmail OAuth path
+        if not CREDENTIALS_PATH.exists():
+            console.print(
+                "  [yellow]⚠  credentials.json not found[/yellow] at "
+                f"[dim]{CREDENTIALS_PATH}[/dim]\n"
+            )
+            console.print("  To get it:")
+            console.print("    1. Go to [cyan]https://console.cloud.google.com[/cyan]")
+            console.print("    2. Create a project  →  Enable the Gmail API")
+            console.print("    3. Create OAuth 2.0 credentials  (Desktop app type)")
+            console.print(f"    4. Download and save as [cyan]{CREDENTIALS_PATH}[/cyan]")
+            console.print()
+            console.print("  [dim]Then re-run:[/dim]  [bold cyan]mailtrim setup[/bold cyan]")
+            console.print()
+            raise typer.Exit(1)
+
+        console.print("  [dim]Opening browser for Google OAuth consent…[/dim]")
+        try:
+            from mailtrim.core.gmail_client import GmailClient, authenticate
+
+            creds = authenticate(credentials_path=CREDENTIALS_PATH)
+            _client = GmailClient(creds)
+            email = _client.get_email_address()
+            console.print(f"  [green]✓[/green]  Authenticated as [bold]{email}[/bold]")
+        except Exception as exc:
+            console.print(f"  [red]✗  Authentication failed:[/red] {str(exc)[:100]}")
+            console.print()
+            console.print(
+                "  Check that your credentials.json is valid, then retry:\n"
+                "  [cyan]mailtrim auth[/cyan]  →  [cyan]mailtrim setup[/cyan]"
+            )
+            console.print()
+            raise typer.Exit(1)
+
+    else:
+        # IMAP path
+        console.print("  You'll need: server hostname, username, and password.")
+        console.print()
+        imap_server = Prompt.ask("  IMAP server", default="imap.gmail.com")
+        imap_user = Prompt.ask("  Username / email")
+        imap_password = Prompt.ask("  Password", password=True)
+        imap_port_str = Prompt.ask("  Port", default="993")
+        try:
+            imap_port = int(imap_port_str)
+        except ValueError:
+            imap_port = 993
+
+        console.print()
+        console.print("  [dim]Testing IMAP connection…[/dim]")
+        try:
+            from mailtrim.core.providers.factory import get_provider
+
+            _client = get_provider(
+                provider="imap",
+                imap_server=imap_server,
+                imap_user=imap_user,
+                imap_password=imap_password,
+                imap_port=imap_port,
+            )
+            _client.get_profile()  # verifies connectivity
+            console.print(
+                f"  [green]✓[/green]  Connected to [bold]{imap_server}[/bold] as [bold]{imap_user}[/bold]"
+            )
+        except Exception as exc:
+            console.print(f"  [red]✗  IMAP connection failed:[/red] {str(exc)[:100]}")
+            console.print()
+            console.print(
+                "  Double-check your server, username, and password, then retry:\n"
+                "  [cyan]mailtrim setup[/cyan]"
+            )
+            console.print()
+            raise typer.Exit(1)
+
+    console.print()
+
+    # ── Step 3: Health check (inline doctor — required checks only) ────────────
+    console.print("[bold]Step 3 of 3[/bold]  ·  System check")
+    console.print()
+
+    # For IMAP setups skip Gmail-specific checks (token/connection checks need OAuth)
+    if provider_choice == "I":
+        from mailtrim.core.diagnostics import (
+            check_config,
+            check_data_dir,
+            check_dependencies,
+            check_undo_storage,
+        )
+
+        check_fns = [check_dependencies, check_config, check_data_dir, check_undo_storage]
+        results = []
+        for fn in check_fns:
+            try:
+                results.append(fn())
+            except Exception as exc:
+                from mailtrim.core.diagnostics import CheckResult
+
+                results.append(CheckResult(fn.__name__, ok=False, message=str(exc)))
+    else:
+        results = run_all(include_optional=False)
+
+    failed = []
+    for r in results:
+        icon = "[green]✓[/green]" if r.ok else "[red]✗[/red]"
+        console.print(f"  {icon}  {r.name}")
+        if not r.ok:
+            console.print(f"     [dim]{r.message}[/dim]")
+            if r.fix:
+                console.print(f"     [cyan]→ {r.fix}[/cyan]")
+            failed.append(r)
+
+    console.print()
+
+    if failed:
+        console.print(
+            f"  [red]{len(failed)} check(s) failed.[/red]  Fix the issues above, then re-run:"
+        )
+        console.print("  [cyan]mailtrim setup[/cyan]")
+        console.print()
+        raise typer.Exit(1)
+
+    console.print("  [green]All checks passed.[/green]  Scanning your inbox…")
+    console.print()
+
+    # ── Quickstart scan (inline — reuses same logic as quickstart command) ─────
+    try:
+        groups = fetch_sender_groups(
+            _client,
+            query="in:inbox",
+            max_messages=500,
+            min_count=2,
+            top_n=50,
+            sort_by="score",
+        )
+        domain_groups = group_by_domain(groups)
+        domain_map_lookup = {d.domain: d for d in domain_groups}
+        recommendations = generate_recommendations(groups, top_n=10, domain_map=domain_map_lookup)
+        bns = best_next_step(recommendations)
+        total_reclaimable = reclaimable_mb(recommendations)
+    except Exception as exc:
+        console.print(f"  [yellow]⚠  Scan failed:[/yellow] {str(exc)[:80]}")
+        console.print(
+            "\n  You're still set up correctly — try manually:\n  [cyan]mailtrim quickstart[/cyan]"
+        )
+        console.print()
+        return  # not a fatal error — auth + doctor passed
+
+    total_emails = sum(g.count for g in groups)
+    safe_count = len(
+        [
+            r
+            for r in recommendations
+            if classify_sender_risk(r.sender) != "sensitive"
+            and compute_confidence_score(r.sender) >= 50
+        ]
+    )
+
+    console.print(
+        f"  Scanned [bold]{total_emails:,}[/bold] emails  ·  "
+        f"[bold]{safe_count}[/bold] safe senders to clean"
+        + (
+            f"  ·  [green]~{total_reclaimable} MB[/green] reclaimable"
+            if total_reclaimable > 0
+            else ""
+        )
+    )
+
+    if (
+        bns
+        and bns.actions
+        and classify_sender_risk(bns.sender) != "sensitive"
+        and compute_confidence_score(bns.sender) >= 50
+    ):
+        g = bns.sender
+        action = bns.actions[0]
+        d = domain_map_lookup.get(g.domain)
+        email_count = d.count if d else g.count
+        size_mb = (d.total_size_mb if d else g.total_size_mb) if action.savings_mb > 0 else 0
+        size_str = f"  ·  {size_mb} MB" if size_mb > 0 else ""
+        console.print()
+        console.print(
+            f"  [bold]Best first action[/bold]  "
+            f"[dim]{g.display_name[:45]} — {email_count:,} emails{size_str}[/dim]"
+        )
+        console.print(f"    [bold cyan]{action.command}[/bold cyan]")
+    elif not recommendations:
+        console.print("  [green]Inbox looks clean![/green]  Nothing obvious to remove right now.")
+
+    console.print()
+    console.print("  [dim]Undo anytime:[/dim]  mailtrim undo")
+
+    # ── Done ──────────────────────────────────────────────────────────────────
+    console.print()
+    console.print(
+        Panel(
+            "[green]You're all set![/green]\n\n"
+            "  [cyan]mailtrim quickstart[/cyan]   — guided first cleanup\n"
+            "  [cyan]mailtrim stats[/cyan]         — full inbox analysis\n"
+            "  [cyan]mailtrim doctor[/cyan]        — re-run health checks anytime",
+            title="[bold green]Setup complete",
+            border_style="green",
+            padding=(0, 2),
+        )
+    )
+    console.print()
+
+
 # ── auth ─────────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,289 @@
+"""Tests for `mailtrim setup` command."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_GOOD_PROFILE = {"emailAddress": "user@gmail.com", "messagesTotal": 3000, "threadsTotal": 2000}
+
+
+def _make_sender(
+    email: str = "news@newsletter.co",
+    name: str = "Newsletter",
+    count: int = 70,
+    size_bytes: int = 12 * 1024 * 1024,
+    inbox_days: int = 180,
+    has_unsubscribe: bool = True,
+):
+    from mailtrim.core.sender_stats import SenderGroup
+
+    now = datetime.now(timezone.utc)
+    return SenderGroup(
+        sender_email=email,
+        sender_name=name,
+        count=count,
+        total_size_bytes=size_bytes,
+        earliest_date=now - timedelta(days=inbox_days),
+        latest_date=now,
+        sample_subjects=["Weekly digest"],
+        message_ids=[f"id{i}" for i in range(count)],
+        has_unsubscribe=has_unsubscribe,
+        impact_score=80,
+    )
+
+
+def _mock_checks_ok():
+    """Return a patch context that makes all doctor checks pass."""
+    from mailtrim.core.diagnostics import CheckResult
+
+    ok_results = [
+        CheckResult("Required packages", ok=True, message="ok"),
+        CheckResult("Config", ok=True, message="ok"),
+        CheckResult("Data directory", ok=True, message="ok"),
+        CheckResult("Undo storage", ok=True, message="ok"),
+        CheckResult("Auth token file", ok=True, message="ok"),
+        CheckResult("Auth token valid", ok=True, message="ok"),
+        CheckResult("Gmail connection", ok=True, message="ok"),
+        CheckResult("Trash access", ok=True, message="ok"),
+    ]
+    return patch("mailtrim.core.diagnostics.run_all", return_value=ok_results)
+
+
+def _invoke_gmail(groups=None, auth_ok=True, checks_ok=True, credentials_exist=True):
+    """Simulate user typing 'G' for Gmail, happy path by default."""
+    from mailtrim.cli.main import app
+    from mailtrim.config import CREDENTIALS_PATH
+
+    if groups is None:
+        groups = [_make_sender()]
+
+    mock_creds = MagicMock()
+    mock_client = MagicMock()
+    mock_client.get_email_address.return_value = "user@gmail.com"
+    mock_client.get_profile.return_value = _GOOD_PROFILE
+
+    from mailtrim.core.diagnostics import CheckResult
+
+    if checks_ok:
+        check_results = [
+            CheckResult("Required packages", ok=True, message="ok"),
+            CheckResult("Config", ok=True, message="ok"),
+            CheckResult("Data directory", ok=True, message="ok"),
+            CheckResult("Undo storage", ok=True, message="ok"),
+            CheckResult("Auth token file", ok=True, message="ok"),
+            CheckResult("Auth token valid", ok=True, message="ok"),
+            CheckResult("Gmail connection", ok=True, message="ok"),
+            CheckResult("Trash access", ok=True, message="ok"),
+        ]
+    else:
+        check_results = [
+            CheckResult("Required packages", ok=True, message="ok"),
+            CheckResult(
+                "Gmail connection",
+                ok=False,
+                message="Session expired",
+                fix="mailtrim auth",
+            ),
+        ]
+
+    with (
+        patch(
+            "mailtrim.cli.main.CREDENTIALS_PATH",
+            CREDENTIALS_PATH if not credentials_exist else CREDENTIALS_PATH,
+        ),
+        patch("mailtrim.config.CREDENTIALS_PATH", CREDENTIALS_PATH),
+        patch("pathlib.Path.exists", return_value=credentials_exist),
+        patch("mailtrim.core.gmail_client.authenticate", return_value=mock_creds),
+        patch(
+            "mailtrim.cli.main._get_client",
+            side_effect=Exception("bad auth") if not auth_ok else lambda: mock_client,
+        ),
+        patch(
+            "mailtrim.core.gmail_client.GmailClient",
+            return_value=mock_client if auth_ok else (_ for _ in ()).throw(Exception("bad auth")),
+        ),
+        patch("mailtrim.core.diagnostics.run_all", return_value=check_results),
+        patch("mailtrim.core.sender_stats.fetch_sender_groups", return_value=groups),
+    ):
+        return runner.invoke(app, ["setup"], input="G\n", catch_exceptions=False)
+
+
+def _invoke_imap(groups=None, imap_ok=True):
+    """Simulate user typing 'I' for IMAP."""
+    from mailtrim.cli.main import app
+
+    if groups is None:
+        groups = [_make_sender()]
+
+    mock_provider = MagicMock()
+    mock_provider.get_profile.return_value = _GOOD_PROFILE
+    if not imap_ok:
+        mock_provider.get_profile.side_effect = Exception("auth failed")
+
+    from mailtrim.core.diagnostics import CheckResult
+
+    check_results = [
+        CheckResult("Required packages", ok=True, message="ok"),
+        CheckResult("Config", ok=True, message="ok"),
+        CheckResult("Data directory", ok=True, message="ok"),
+        CheckResult("Undo storage", ok=True, message="ok"),
+    ]
+
+    imap_input = "I\nimap.example.com\nuser@example.com\nsecret\n993\n"
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("mailtrim.core.providers.factory.get_provider", return_value=mock_provider),
+        patch("mailtrim.core.diagnostics.run_all", return_value=check_results),
+        patch("mailtrim.core.sender_stats.fetch_sender_groups", return_value=groups),
+    ):
+        return runner.invoke(app, ["setup"], input=imap_input, catch_exceptions=False)
+
+
+# ── Welcome message ───────────────────────────────────────────────────────────
+
+
+def test_welcome_shows_time_estimate():
+    result = _invoke_gmail()
+    assert "1–2 minutes" in result.output
+
+
+def test_welcome_shows_safety_note():
+    result = _invoke_gmail()
+    assert "deleted without your explicit command" in result.output
+
+
+# ── Provider selection ────────────────────────────────────────────────────────
+
+
+def test_shows_gmail_option():
+    result = _invoke_gmail()
+    assert "Gmail" in result.output
+
+
+def test_shows_imap_option():
+    result = _invoke_gmail()
+    assert "IMAP" in result.output
+
+
+# ── Gmail auth ────────────────────────────────────────────────────────────────
+
+
+def test_gmail_happy_path_exits_0():
+    result = _invoke_gmail()
+    assert result.exit_code == 0
+
+
+def test_gmail_shows_authenticated_account():
+    result = _invoke_gmail()
+    assert "user@gmail.com" in result.output
+
+
+def test_missing_credentials_exits_1():
+    result = _invoke_gmail(credentials_exist=False)
+    assert result.exit_code == 1
+
+
+def test_missing_credentials_shows_steps():
+    result = _invoke_gmail(credentials_exist=False)
+    assert "console.cloud.google.com" in result.output or "cloud.google.com" in result.output
+
+
+def test_missing_credentials_shows_retry_hint():
+    result = _invoke_gmail(credentials_exist=False)
+    assert "mailtrim setup" in result.output
+
+
+# ── Doctor checks ─────────────────────────────────────────────────────────────
+
+
+def test_shows_step_3_health_check():
+    result = _invoke_gmail()
+    assert "Step 3" in result.output
+
+
+def test_shows_check_icons():
+    result = _invoke_gmail()
+    assert "✓" in result.output
+
+
+def test_doctor_failure_exits_1():
+    result = _invoke_gmail(checks_ok=False)
+    assert result.exit_code == 1
+
+
+def test_doctor_failure_shows_fix():
+    result = _invoke_gmail(checks_ok=False)
+    assert "mailtrim auth" in result.output or "Fix" in result.output
+
+
+def test_doctor_failure_shows_retry_hint():
+    result = _invoke_gmail(checks_ok=False)
+    assert "mailtrim setup" in result.output
+
+
+# ── Quickstart scan ───────────────────────────────────────────────────────────
+
+
+def test_shows_emails_scanned():
+    result = _invoke_gmail()
+    assert "emails" in result.output
+
+
+def test_shows_safe_sender_count():
+    result = _invoke_gmail(groups=[_make_sender()])
+    assert "safe senders to clean" in result.output
+
+
+def test_shows_best_action_command():
+    result = _invoke_gmail(groups=[_make_sender()])
+    assert "mailtrim purge" in result.output
+
+
+def test_shows_undo_hint():
+    result = _invoke_gmail()
+    assert "mailtrim undo" in result.output
+
+
+def test_clean_inbox_message():
+    result = _invoke_gmail(groups=[])
+    assert result.exit_code == 0
+    assert "clean" in result.output.lower() or "nothing" in result.output.lower()
+
+
+# ── Done / setup complete ─────────────────────────────────────────────────────
+
+
+def test_shows_setup_complete():
+    result = _invoke_gmail()
+    assert "Setup complete" in result.output or "all set" in result.output.lower()
+
+
+def test_shows_next_commands():
+    result = _invoke_gmail()
+    assert "mailtrim quickstart" in result.output
+    assert "mailtrim stats" in result.output
+
+
+# ── IMAP path ─────────────────────────────────────────────────────────────────
+
+
+def test_imap_happy_path_exits_0():
+    result = _invoke_imap()
+    assert result.exit_code == 0
+
+
+def test_imap_failure_exits_1():
+    result = _invoke_imap(imap_ok=False)
+    assert result.exit_code == 1
+
+
+def test_imap_failure_shows_retry_hint():
+    result = _invoke_imap(imap_ok=False)
+    assert "mailtrim setup" in result.output


### PR DESCRIPTION
## Summary

New `mailtrim setup` command — end-to-end guided onboarding in ~1–2 minutes.

## Flow

```
Step 1 of 3  ·  Choose your email provider
  G  Gmail via OAuth  (recommended — opens browser)
  I  IMAP  (Outlook, Yahoo, custom server)

> G

Step 2 of 3  ·  Connect your account
  Opening browser for Google OAuth consent…
  ✓  Authenticated as user@gmail.com

Step 3 of 3  ·  System check
  ✓  Required packages
  ✓  Configuration
  ✓  Data directory
  ✓  Undo storage
  ✓  Auth token file
  ✓  Auth token valid
  ✓  Gmail connection
  ✓  Trash access

  All checks passed.  Scanning your inbox…

  Scanned 342 emails  ·  4 safe senders to clean  ·  ~38 MB reclaimable

  Best first action  Newsletter Co — 89 emails  ·  12 MB
    mailtrim purge --domain newsletter.co --yes

  Undo anytime:  mailtrim undo

╭─ Setup complete ──────────────────────────────────────╮
│  You're all set!                                      │
│  mailtrim quickstart   — guided first cleanup         │
│  mailtrim stats         — full inbox analysis         │
│  mailtrim doctor        — re-run health checks        │
╰───────────────────────────────────────────────────────╯
```

## Design decisions

- **No dead ends**: every failure path prints an exact command to run next (`mailtrim auth`, `mailtrim setup`)
- **IMAP skips Gmail-specific doctor checks** (token/connection checks require OAuth) — runs deps/config/data-dir/undo-storage only
- **Scan failure is non-fatal**: if the inbox scan fails after auth+doctor pass, user gets a graceful note + `mailtrim quickstart` hint rather than an error exit
- **Reuses underlying functions directly**: `run_all()` from diagnostics, `fetch_sender_groups` / `best_next_step` / `generate_recommendations` from sender_stats — same logic as `doctor` and `quickstart`, not copy-pasted

## Test plan

- [x] Welcome: time estimate shown, safety note shown
- [x] Provider selection: Gmail and IMAP options visible
- [x] Gmail happy path: exits 0, account shown
- [x] Missing credentials.json: exits 1, Google Cloud Console URL shown, retry hint shown
- [x] Doctor failure: exits 1, fix hint shown, `mailtrim setup` retry shown
- [x] Scan results: email count, safe sender count, best action command, undo hint
- [x] Clean inbox: exits 0 with friendly message
- [x] Setup complete panel: shows quickstart + stats commands
- [x] IMAP happy path: exits 0
- [x] IMAP failure: exits 1, retry hint shown
- [x] `python -m pytest tests/test_setup.py -v` — 24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)