### PR TITLE
feat: time-based filtering — stats/purge --since <Nd>

### DIFF
--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -254,6 +254,11 @@ def stats(
     simple: bool = typer.Option(
         False, "--simple", help="Plain-language output — no scores or tables."
     ),
+    since: str = typer.Option(
+        "",
+        "--since",
+        help="Only scan emails received within the last N days. Format: 30d, 7d.",
+    ),
 ):
     """
     Inbox decision engine — reclaimable space, confidence-scored recommendations, top senders.
@@ -266,6 +271,7 @@ def stats(
       mailtrim stats --sort size
       mailtrim stats --scope anywhere   # include archived and sent mail
       mailtrim stats --max-scan 5000    # scan more of a large mailbox
+      mailtrim stats --since 30d        # only emails from the last 30 days
       mailtrim stats --share              # twitter-style summary (≤280 chars)
       mailtrim stats --share --format plain  # plain-text version
     """
@@ -300,6 +306,18 @@ def stats(
     else:
         mail_query = "in:inbox"
         scope_label = "inbox"
+
+    from mailtrim.core.validation import validate_since
+
+    since_days: int | None = None
+    if since:
+        try:
+            since_days = validate_since(since)
+        except typer.BadParameter as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(1)
+        mail_query += f" newer_than:{since_days}d"
+        scope_label += f" · last {since_days}d"
 
     scan_start = _time.time()
 
@@ -471,9 +489,10 @@ def stats(
             f"[dim]({insights.total_scanned:,} emails · {insights.unique_senders} senders)[/dim]"
         )
     else:
+        _since_note = f" · last {since_days}d" if since_days else ""
         console.print(
             f"[dim]  ✨ Scan complete — analyzed {insights.total_scanned:,} emails "
-            f"across {insights.unique_senders} senders in {scan_elapsed}s[/dim]"
+            f"across {insights.unique_senders} senders in {scan_elapsed}s{_since_note}[/dim]"
         )
     console.print()
 
@@ -1932,6 +1951,11 @@ def purge(
     ),
     ai_url: str = typer.Option("", "--ai-url", help="Override local AI server URL."),
     ai_model: str = typer.Option("phi3", "--ai-model", help="Model name (Ollama only)."),
+    since: str = typer.Option(
+        "",
+        "--since",
+        help="Only scan emails received within the last N days. Format: 30d, 7d.",
+    ),
 ):
     """
     Move top email senders to Trash — with a 30-day undo window.
@@ -1945,6 +1969,8 @@ def purge(
       mailtrim purge --domain linkedin.com --yes
       mailtrim purge --domain linkedin.com --keep 10
       mailtrim purge --domain linkedin.com --older-than 90
+      mailtrim purge --domain linkedin.com --since 30d   # only last 30 days
+      mailtrim purge --since 7d                          # emails from last 7 days
       mailtrim purge --domain linkedin.com --yes --share
       mailtrim purge --query "category:promotions" --top 20
       mailtrim purge --unsub   # also unsubscribe while deleting
@@ -1956,7 +1982,7 @@ def purge(
     from mailtrim.core.sender_stats import compute_confidence_score, fetch_sender_groups
     from mailtrim.core.storage import UndoLogRepo, get_session
     from mailtrim.core.unsubscribe import UnsubscribeEngine
-    from mailtrim.core.validation import validate_domain, validate_older_than
+    from mailtrim.core.validation import validate_domain, validate_older_than, validate_since
 
     # Guard: --permanent requires the explicit confirmation flag to prevent accidents.
     if permanent and not i_understand_permanent:
@@ -1992,11 +2018,23 @@ def purge(
     if older_than is not None:
         older_than = validate_older_than(older_than)
 
+    since_days: int | None = None
+    if since:
+        try:
+            since_days = validate_since(since)
+        except typer.BadParameter as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(1)
+
     # --scope prepends a scope filter to the query unless --query is explicitly set
     if scope == "anywhere" and query == "category:promotions OR label:newsletters":
         query = "in:anywhere -in:trash -in:spam"
     elif scope == "anywhere":
         query = f"in:anywhere -in:trash -in:spam {query}"
+
+    # --since appends a date lower bound to whatever query is in use
+    if since_days:
+        query += f" newer_than:{since_days}d"
 
     # --domain builds a targeted query and routes to non-interactive mode.
     # Scope filter is always applied so the count matches what stats showed.
@@ -2007,6 +2045,8 @@ def purge(
             effective_query = f"in:inbox from:{domain}"
         if older_than:
             effective_query += f" older_than:{older_than}d"
+        if since_days:
+            effective_query += f" newer_than:{since_days}d"
         query = effective_query
 
     scope_label = "all mail" if scope == "anywhere" else "inbox"

--- a/mailtrim/core/providers/imap.py
+++ b/mailtrim/core/providers/imap.py
@@ -77,7 +77,7 @@ def _gmail_query_to_imap(query: str) -> tuple[str, str]:
     if m:
         parts.append(f'FROM "{m.group(1)}"')
 
-    # Age filter — older_than:Nd
+    # Age filter — older_than:Nd → BEFORE (exclusive upper bound)
     m = re.search(r"older_than:(\d+)d", query)
     if m:
         days = int(m.group(1))
@@ -85,6 +85,15 @@ def _gmail_query_to_imap(query: str) -> tuple[str, str]:
         dt = datetime.fromtimestamp(cutoff, tz=timezone.utc)
         # IMAP BEFORE uses DD-Mon-YYYY format
         parts.append(f'BEFORE "{dt.strftime("%d-%b-%Y")}"')
+
+    # Since filter — newer_than:Nd → SINCE (inclusive lower bound)
+    m = re.search(r"newer_than:(\d+)d", query)
+    if m:
+        days = int(m.group(1))
+        cutoff = datetime.now(tz=timezone.utc).timestamp() - days * 86400
+        dt = datetime.fromtimestamp(cutoff, tz=timezone.utc)
+        # IMAP SINCE uses DD-Mon-YYYY format
+        parts.append(f'SINCE "{dt.strftime("%d-%b-%Y")}"')
 
     # Subject filter
     m = re.search(r'subject:"([^"]+)"', query)

--- a/mailtrim/core/validation.py
+++ b/mailtrim/core/validation.py
@@ -88,3 +88,35 @@ def validate_older_than(days: int) -> int:
             f"--older-than value {days} exceeds 100 years — did you mean something else?"
         )
     return days
+
+
+# ── Since / date range ────────────────────────────────────────────────────────
+
+_SINCE_RE = re.compile(r"^(\d+)d$")
+_MAX_SINCE_DAYS = 36_500  # 100 years
+
+
+def validate_since(value: str) -> int:
+    """
+    Parse and validate a ``--since <Nd>`` argument.
+
+    Accepts: ``30d``, ``7d``, ``365d``
+    Rejects: ``30``, ``d``, ``0d``, negative values, values > 100 years.
+
+    Returns the number of days as an int on success.
+    Raises typer.BadParameter on failure.
+    """
+    m = _SINCE_RE.match(value.strip())
+    if not m:
+        raise typer.BadParameter(
+            f"'{value}' is not a valid --since value. "
+            "Use the format <N>d, e.g. --since 30d or --since 7d."
+        )
+    days = int(m.group(1))
+    if days <= 0:
+        raise typer.BadParameter(f"--since must be at least 1 day (got {days}d).")
+    if days > _MAX_SINCE_DAYS:
+        raise typer.BadParameter(
+            f"--since value {days}d exceeds 100 years — did you mean something else?"
+        )
+    return days

--- a/tests/test_since_filter.py
+++ b/tests/test_since_filter.py
@@ -1,0 +1,315 @@
+"""Tests for --since <Nd> time-based filtering."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+# ── validate_since unit tests ─────────────────────────────────────────────────
+
+
+class TestValidateSince:
+    def _v(self, value: str) -> int:
+        from mailtrim.core.validation import validate_since
+
+        return validate_since(value)
+
+    def test_valid_30d(self):
+        assert self._v("30d") == 30
+
+    def test_valid_7d(self):
+        assert self._v("7d") == 7
+
+    def test_valid_1d(self):
+        assert self._v("1d") == 1
+
+    def test_valid_365d(self):
+        assert self._v("365d") == 365
+
+    def test_valid_with_whitespace(self):
+        assert self._v("  30d  ") == 30
+
+    def test_missing_d_suffix(self):
+        with pytest.raises(typer.BadParameter, match="format"):
+            self._v("30")
+
+    def test_zero_days(self):
+        with pytest.raises(typer.BadParameter, match="at least 1"):
+            self._v("0d")
+
+    def test_non_numeric(self):
+        with pytest.raises(typer.BadParameter, match="format"):
+            self._v("abcd")
+
+    def test_empty_string(self):
+        with pytest.raises(typer.BadParameter):
+            self._v("")
+
+    def test_negative_not_accepted(self):
+        # "-30d" doesn't match the regex (no leading minus allowed)
+        with pytest.raises(typer.BadParameter):
+            self._v("-30d")
+
+    def test_over_100_years_rejected(self):
+        with pytest.raises(typer.BadParameter, match="100 years"):
+            self._v("36501d")
+
+    def test_exactly_100_years_ok(self):
+        assert self._v("36500d") == 36500
+
+
+# ── IMAP query translation ────────────────────────────────────────────────────
+
+
+class TestImapQueryTranslation:
+    def _translate(self, query: str):
+        from mailtrim.core.providers.imap import _gmail_query_to_imap
+
+        return _gmail_query_to_imap(query)
+
+    def test_newer_than_produces_since(self):
+        _, criteria = self._translate("in:inbox newer_than:30d")
+        assert "SINCE" in criteria
+
+    def test_newer_than_date_format(self):
+        """IMAP SINCE uses DD-Mon-YYYY format."""
+        _, criteria = self._translate("in:inbox newer_than:7d")
+        import re
+
+        assert re.search(r"SINCE \"\d{2}-[A-Z][a-z]{2}-\d{4}\"", criteria)
+
+    def test_newer_than_date_is_recent(self):
+        """The SINCE date should be within the last N+1 days."""
+        _, criteria = self._translate("in:inbox newer_than:30d")
+        import re
+        from datetime import datetime
+
+        m = re.search(r'SINCE "(\d{2}-[A-Z][a-z]{2}-\d{4})"', criteria)
+        assert m, f"No SINCE date found in: {criteria}"
+        dt = datetime.strptime(m.group(1), "%d-%b-%Y")
+        days_ago = (datetime.now() - dt).days
+        assert 29 <= days_ago <= 31  # ±1 day tolerance for day boundaries
+
+    def test_older_than_and_newer_than_coexist(self):
+        """Both BEFORE and SINCE can appear in one query (date range)."""
+        _, criteria = self._translate("in:inbox older_than:90d newer_than:30d")
+        assert "BEFORE" in criteria
+        assert "SINCE" in criteria
+
+    def test_no_newer_than_produces_no_since(self):
+        _, criteria = self._translate("in:inbox")
+        assert "SINCE" not in criteria
+
+    def test_inbox_scope_preserved(self):
+        folder, _ = self._translate("in:inbox newer_than:7d")
+        assert folder == "INBOX"
+
+
+# ── Gmail query construction ──────────────────────────────────────────────────
+
+
+class TestGmailQueryConstruction:
+    """Verify that --since injects newer_than into the query string."""
+
+    def _make_client(self, groups=None):
+        from mailtrim.core.sender_stats import SenderGroup
+
+        if groups is None:
+            now = datetime.now(timezone.utc)
+            groups = [
+                SenderGroup(
+                    sender_email="news@example.com",
+                    sender_name="Example",
+                    count=30,
+                    total_size_bytes=5 * 1024 * 1024,
+                    earliest_date=now - timedelta(days=20),
+                    latest_date=now,
+                    sample_subjects=["Newsletter"],
+                    message_ids=[f"id{i}" for i in range(30)],
+                    has_unsubscribe=True,
+                    impact_score=70,
+                )
+            ]
+
+        mock = MagicMock()
+        mock.get_profile.return_value = {
+            "emailAddress": "user@gmail.com",
+            "messagesTotal": 3000,
+            "threadsTotal": 2000,
+        }
+        mock.list_message_ids.return_value = [g.message_ids[0] for g in groups]
+        return mock, groups
+
+    def test_stats_since_appends_newer_than_to_query(self):
+        from mailtrim.cli.main import app
+
+        mock_client, groups = self._make_client()
+        captured_queries: list[str] = []
+
+        def fake_fetch(client, query, **kwargs):
+            captured_queries.append(query)
+            return groups
+
+        with (
+            patch("mailtrim.cli.main._get_provider", return_value=mock_client),
+            patch("mailtrim.core.sender_stats.fetch_sender_groups", side_effect=fake_fetch),
+        ):
+            result = runner.invoke(app, ["stats", "--since", "30d"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert any("newer_than:30d" in q for q in captured_queries)
+
+    def test_stats_no_since_no_newer_than(self):
+        from mailtrim.cli.main import app
+
+        mock_client, groups = self._make_client()
+        captured_queries: list[str] = []
+
+        def fake_fetch(client, query, **kwargs):
+            captured_queries.append(query)
+            return groups
+
+        with (
+            patch("mailtrim.cli.main._get_provider", return_value=mock_client),
+            patch("mailtrim.core.sender_stats.fetch_sender_groups", side_effect=fake_fetch),
+        ):
+            result = runner.invoke(app, ["stats"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert all("newer_than" not in q for q in captured_queries)
+
+    def test_stats_since_with_scope_anywhere(self):
+        from mailtrim.cli.main import app
+
+        mock_client, groups = self._make_client()
+        captured_queries: list[str] = []
+
+        def fake_fetch(client, query, **kwargs):
+            captured_queries.append(query)
+            return groups
+
+        with (
+            patch("mailtrim.cli.main._get_provider", return_value=mock_client),
+            patch("mailtrim.core.sender_stats.fetch_sender_groups", side_effect=fake_fetch),
+        ):
+            result = runner.invoke(
+                app, ["stats", "--since", "7d", "--scope", "anywhere"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0
+        assert any("newer_than:7d" in q and "in:anywhere" in q for q in captured_queries)
+
+    def test_purge_since_appends_newer_than_to_query(self):
+        from mailtrim.cli.main import app
+
+        mock_client, groups = self._make_client()
+        captured_queries: list[str] = []
+
+        def fake_fetch(client, query, **kwargs):
+            captured_queries.append(query)
+            return groups
+
+        with (
+            patch("mailtrim.cli.main._get_provider", return_value=mock_client),
+            patch("mailtrim.cli.main._get_account_email", return_value="user@gmail.com"),
+            patch("mailtrim.core.sender_stats.fetch_sender_groups", side_effect=fake_fetch),
+            patch("mailtrim.core.storage.BlocklistRepo") as mock_bl,
+        ):
+            mock_bl.return_value.blocked_emails.return_value = set()
+            result = runner.invoke(
+                app, ["purge", "--since", "30d", "--json"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0
+        assert any("newer_than:30d" in q for q in captured_queries)
+
+    def test_purge_domain_and_since(self):
+        from mailtrim.cli.main import app
+
+        mock_client, groups = self._make_client()
+        captured_queries: list[str] = []
+
+        def fake_fetch(client, query, **kwargs):
+            captured_queries.append(query)
+            return groups
+
+        with (
+            patch("mailtrim.cli.main._get_provider", return_value=mock_client),
+            patch("mailtrim.cli.main._get_account_email", return_value="user@gmail.com"),
+            patch("mailtrim.core.sender_stats.fetch_sender_groups", side_effect=fake_fetch),
+            patch("mailtrim.core.storage.BlocklistRepo") as mock_bl,
+        ):
+            mock_bl.return_value.blocked_emails.return_value = set()
+            result = runner.invoke(
+                app,
+                ["purge", "--domain", "example.com", "--since", "30d", "--json"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        assert any("newer_than:30d" in q and "from:example.com" in q for q in captured_queries)
+
+
+# ── CLI validation errors ──────────────────────────────────────────────────────
+
+
+class TestCLIValidationErrors:
+    def _mock_provider(self):
+        mock = MagicMock()
+        mock.get_profile.return_value = {
+            "emailAddress": "user@gmail.com",
+            "messagesTotal": 0,
+            "threadsTotal": 0,
+        }
+        return mock
+
+    def test_stats_invalid_since_exits_1(self):
+        from mailtrim.cli.main import app
+
+        with patch("mailtrim.cli.main._get_provider", return_value=self._mock_provider()):
+            result = runner.invoke(app, ["stats", "--since", "badvalue"], catch_exceptions=False)
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+    def test_stats_since_zero_exits_1(self):
+        from mailtrim.cli.main import app
+
+        with patch("mailtrim.cli.main._get_provider", return_value=self._mock_provider()):
+            result = runner.invoke(app, ["stats", "--since", "0d"], catch_exceptions=False)
+        assert result.exit_code == 1
+
+    def test_stats_since_no_d_suffix_exits_1(self):
+        from mailtrim.cli.main import app
+
+        with patch("mailtrim.cli.main._get_provider", return_value=self._mock_provider()):
+            result = runner.invoke(app, ["stats", "--since", "30"], catch_exceptions=False)
+        assert result.exit_code == 1
+
+    def test_purge_invalid_since_exits_1(self):
+        from mailtrim.cli.main import app
+
+        with patch("mailtrim.cli.main._get_provider", return_value=self._mock_provider()):
+            result = runner.invoke(app, ["purge", "--since", "xyz"], catch_exceptions=False)
+        assert result.exit_code == 1
+
+    def test_stats_scope_label_includes_since(self):
+        """When --since is used the scan label should mention the time window."""
+        from mailtrim.cli.main import app
+
+        mock_client = self._mock_provider()
+
+        with (
+            patch("mailtrim.cli.main._get_provider", return_value=mock_client),
+            patch("mailtrim.core.sender_stats.fetch_sender_groups", return_value=[]),
+        ):
+            result = runner.invoke(app, ["stats", "--since", "7d"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert "7d" in result.output


### PR DESCRIPTION
## Summary

Adds `--since <Nd>` to `mailtrim stats` and `mailtrim purge` for scanning only emails received within the last N days.

```bash
mailtrim stats --since 30d          # last 30 days only
mailtrim stats --since 7d --scope anywhere
mailtrim purge --since 30d          # purge within last 30 days
mailtrim purge --domain linkedin.com --since 7d --yes
mailtrim purge --since 30d --older-than 7   # date range: 7–30 days old
```

## Implementation

Three layers, each independently testable:

### 1. `validation.py` — `validate_since(value: str) -> int`
- Parses `"30d"` → `30`; rejects missing `d`, zero, negatives, >100 years
- Same error-surfacing pattern as `validate_older_than`

### 2. `providers/imap.py` — `_gmail_query_to_imap`
- Added `newer_than:Nd` → `SINCE "DD-Mon-YYYY"` mapping
- Complements the existing `older_than:Nd` → `BEFORE` mapping
- Both can coexist for date-range queries (e.g. emails from 7–30 days ago)

### 3. `cli/main.py` — stats + purge
- **stats**: validates `--since`, appends `newer_than:{N}d` to `mail_query`, shows `· last Nd` in scan-complete output
- **purge (base query)**: appends `newer_than:{N}d` after scope processing
- **purge `--domain` path**: appends to `effective_query` so domain filter + since filter are both active
- Default unchanged: no `--since` → same behaviour as before

### Compatibility
| Provider | Mechanism |
|----------|-----------|
| Gmail API | `newer_than:Nd` is a native Gmail search operator |
| IMAP | Translated to `SINCE "DD-Mon-YYYY"` by `_gmail_query_to_imap` |

## Test plan

- [x] `validate_since`: 12 unit tests — valid inputs, missing `d`, `0d`, non-numeric, >100 years, whitespace, exact boundary
- [x] `_gmail_query_to_imap`: 6 tests — SINCE format, date accuracy (±1 day), BEFORE+SINCE coexistence, no-since case, folder preserved
- [x] CLI integration: 10 tests — query injection confirmed for stats/purge, `--domain+--since`, `--scope+--since`, invalid inputs exit 1, scan output shows window
- [x] `python -m pytest tests/test_since_filter.py -v` — 28 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)