### PR TITLE
feat: AI trust boundary — visible mode enforcement + cloud warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.3.0] — 2026-05-01
+
+### Added
+- `mailtrim setup` — guided first-time onboarding: provider selection (Gmail/IMAP),
+  auth, health checks, and first inbox scan in ~2 minutes
+- `mailtrim stats --since <Nd>` and `mailtrim purge --since <Nd>` — time-based filtering;
+  translates to `newer_than:Nd` for Gmail and `SINCE` criteria for IMAP
+- `mailtrim stats --share` — shareable summary output in Twitter (≤280 chars) or plain format;
+  no personal data, top domains only
+- **AI trust boundary system** — `ai_status_line()` helper; AI state badge (`AI: OFF / LOCAL / CLOUD`)
+  visible in `stats`, `quickstart`, and `doctor`; `_cloud_ai_warning()` panel shown before any
+  cloud AI command; `require_cloud()` wrapped in try/except in all four AI commands for clean exits
+
+### Changed
+- `quickstart` redesigned for instant value: ≤10 lines of output, safe candidates, undo hint,
+  best first action surfaced immediately
+- README rewritten for v0.3.0: trust-first framing, 35% shorter, structured for GitHub visitors
+- `AIModeError` now renders multi-line messages in `_handle_error` (first line bold, rest dim)
+
+---
+
 ## [0.2.1] — 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # mailtrim
 
-**mailtrim helps you clean your inbox safely in seconds — everything goes to Trash first, undo anytime, nothing leaves your machine.**
-
-Free, open-source. Core features need no API key.
+**Clean your inbox safely in seconds.**
+Everything goes to Trash. Undo anytime.
 
 [![PyPI](https://img.shields.io/pypi/v/mailtrim.svg)](https://pypi.org/project/mailtrim/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://python.org)
@@ -11,445 +10,288 @@ Free, open-source. Core features need no API key.
 
 ---
 
-> 🤯 495 emails deleted · 87.4 MB freed in 8s using mailtrim
-> 💥 34% of your inbox is clutter — caused by just 3 senders.
+## Quick Demo
 
-mailtrim is a CLI tool that finds inbox clutter, ranks it by impact, and bulk-deletes it safely — with a 30-day undo window.
+```bash
+pip install mailtrim
+mailtrim setup          # connect Gmail or IMAP — guided, ~2 minutes
+mailtrim stats          # rank your inbox clutter by impact
+mailtrim purge          # bulk-delete what you picked — goes to Trash
+```
 
-**Core workflow (`stats`, `purge`, `undo`) is fully local** — no API key required, nothing sent anywhere. Optional AI commands (`triage`, `bulk`, `avoid`, `digest`, `rules --add`) send only email subjects and 300-character snippets to Anthropic for classification — never full body content. See [Anthropic's privacy policy](https://www.anthropic.com/privacy) for how API data is handled on their side.
-
-No subscription. No black box.
+That's the whole workflow. No API key. No subscription. Nothing sent to any server.
 
 ---
 
-## Why not SaneBox / Superhuman?
+## Why mailtrim?
 
-The paid tools charge $7–$40/month, process your email on their servers, and still don't solve the problems that matter most:
+- **Finds what's actually filling your inbox** — ranks senders by storage impact, not just count
+- **Bulk cleanup in seconds** — delete 300+ emails from one sender in a single command
+- **Nothing is permanently deleted** — everything goes to Trash, recoverable for 30 days
+- **Privacy-first** — core commands run entirely on your machine; AI is opt-in and off by default
+- **Works with Gmail and IMAP** — Outlook, Fastmail, iCloud, any IMAP server
 
-| Problem | SaneBox / Superhuman | mailtrim |
-|---------|----------------------|------------|
-| "Remind me only if they haven't replied" | ✗ Not solved | ✅ Conditional follow-up |
-| *Why* did AI move this email? | ✗ Black box | ✅ One-line explanation per email |
-| Natural language bulk cleanup | ✗ Not solved | ✅ "Archive newsletters older than 60 days" |
-| 30-day undo for bulk operations | ✗ Not solved | ✅ Full undo log |
-| "Emails I keep avoiding" detection | ✗ Not solved | ✅ AI insight per avoided email |
-| Unsubscribe success rate | 70–85% | ✅ Near-100% (headless browser fallback) |
-| Privacy — core commands local | ✗ Cloud-processed | ✅ Core: local only. AI commands: subjects/snippets to Anthropic |
-| Cost | $7–$40/month | **Free** |
+---
+
+## Safety Guarantees
+
+| Guarantee | How it works |
+|---|---|
+| Trash first | Every delete sends mail to Trash, not permanent deletion |
+| Full undo | `mailtrim undo` reverses any operation within 30 days |
+| No cloud required | `stats`, `purge`, `undo`, `setup` are 100% local |
+| AI is optional | AI is `off` by default — you enable it explicitly |
+| Dry-run available | `purge --json` shows what would be deleted before you confirm |
+
+---
+
+## 60-Second Quickstart
+
+**First time:**
+
+```bash
+pip install mailtrim
+mailtrim setup    # walks you through Gmail auth and runs your first scan
+```
+
+**After setup:**
+
+```bash
+mailtrim stats                          # see your inbox ranked by clutter
+mailtrim purge                          # interactive: pick senders, confirm, done
+mailtrim purge --domain linkedin.com    # target one sender directly
+mailtrim undo                           # reverse anything you just did
+```
+
+**Already set up? Jump straight to cleanup:**
+
+```bash
+mailtrim quickstart    # one command — scans, ranks, shows the safest first action
+```
+
+---
+
+## Example Output
+
+### `mailtrim stats`
+
+```
+✨ Scan complete — analyzed 2,341 emails across 41 senders in 4s
+  AI: OFF  no data leaves your machine
+
+34% of your inbox is clutter — caused by just 3 senders. 87.4 MB gone in one command.
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  TOTAL RECLAIMABLE SPACE                                                    │
+│  You can safely free ~87.4 MB (34% of scanned inbox)                       │
+│  from your top 3 senders · Each cleanup takes ~3-5s                        │
+│  All deletions go to Trash — undo anytime                                   │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+ #  Impact    Sender                Emails  Size    Oldest      Risk
+ 1  100       LinkedIn Jobs            312  44 MB   847d ago    Safe to clean
+ 2   82       Substack Weekly          183  26 MB   512d ago    Safe to clean
+ 3   29       Shopify Receipts          94  12 MB   203d ago    Safe to clean
+```
+
+### `mailtrim purge`
+
+```
+  Top Email Offenders  (589 emails · 82 MB)
+
+ # │ Sender              │ Emails │ Size  │ Latest  │ Sample subject
+───┼─────────────────────┼────────┼───────┼─────────┼─────────────────────────
+ 1 │ LinkedIn Jobs       │   312  │  44MB │ Apr 03  │ 12 new jobs matching…
+ 2 │ Substack Weekly     │   183  │  26MB │ Apr 01  │ This week: AI is eating…
+ 3 │ Shopify Receipts    │    94  │  12MB │ Mar 28  │ Your order has shipped
+
+Your selection: 1,2
+
+Move 495 emails to Trash? (undo available for 30 days) [y/N]: y
+✓ Moved 495 emails to Trash.  mailtrim undo 1  — to reverse
+```
+
+### `mailtrim undo`
+
+```
+  Recent operations
+
+  #1  Apr 05  495 emails trashed  (LinkedIn Jobs + Substack)
+  #2  Apr 03   94 emails trashed  (Shopify Receipts)
+
+Restore which operation? 1
+
+✓ Restored 495 emails.
+```
 
 ---
 
 ## Privacy
 
-- **All data stays in `~/.mailtrim/`** — no external servers, no telemetry, no analytics
-- **OAuth token** is written `chmod 0o600` (owner read-only)
-- **Local AI (Ollama/llama.cpp)** — fully offline; nothing leaves your machine. Use `--ai-backend ollama` or `--ai-backend llama`.
-- **Cloud AI features** send only email subjects and snippets to Anthropic — never full body content. See [Anthropic's privacy policy](https://www.anthropic.com/privacy) for their data handling.
-- **No AI key?** — everything except `triage`, `bulk`, `avoid`, `digest`, and `rules --add` works without one. Local AI enrichment also needs no Anthropic key.
-- **Why `gmail.modify` scope?** This grants read, compose, trash, and label access — mailtrim uses it to list messages, move mail to Trash, and manage labels. The scope technically permits reading full body content; mailtrim fetches metadata only and never reads or stores body text.
-- **Why `gmail.send` scope?** The `follow-up` command creates reminder drafts. It is never called by `stats`, `purge`, `triage`, `bulk`, `undo`, or any cleanup command. If you don't use `follow-up`, this permission is never exercised.
-- **Revoking access:** Go to [myaccount.google.com/permissions](https://myaccount.google.com/permissions) and remove mailtrim. Delete `~/.mailtrim/token.json` locally to complete the removal.
-- See [PRIVACY.md](PRIVACY.md) for the full data flow
+**Data never leaves your machine unless you explicitly enable cloud AI.**
+
+- All data stored in `~/.mailtrim/` — no telemetry, no analytics, no external sync
+- OAuth token written `chmod 0600` — owner read-only
+- `stats`, `purge`, `undo`, `setup` are fully local — no API key, no network calls
+- **AI mode** is shown in every command output:
+  - `AI: OFF   no data leaves your machine` (default)
+  - `AI: LOCAL  runs on your machine — nothing sent externally`
+  - `AI: CLOUD  email data may be sent to Anthropic`
+- When cloud AI is enabled, a warning appears **before** any data is sent
+- Cloud AI features send only email subjects and 300-character snippets — never full body content
+
+**Revoke access at any time:**
+- Google: [myaccount.google.com/permissions](https://myaccount.google.com/permissions) → remove mailtrim
+- Local: `rm ~/.mailtrim/token.json`
+
+See [PRIVACY.md](PRIVACY.md) for the full data flow.
 
 ---
 
-## What's free vs. paid?
+## Commands Overview
 
-| Feature | Commands | Cost |
-|---------|----------|------|
-| Inbox analysis + bulk delete | `stats`, `purge`, `undo`, `sync`, `unsubscribe`, `follow-up`, `rules --run` | **Free — no API key needed** |
-| Local AI enrichment (sender confidence) | `stats --ai-backend ollama`, `purge --ai-backend llama` | **Free — runs on your machine** (requires Ollama or llama.cpp) |
-| Cloud AI classification + NL cleanup | `triage`, `bulk`, `avoid`, `digest`, `rules --add` | Requires [Anthropic API key](https://console.anthropic.com) · ~$0.01–0.05 per run |
+### Core (no API key needed)
 
-The core cleanup workflow — scan, rank, delete, undo — costs nothing and requires no AI key. Local AI enrichment (Ollama/llama.cpp) is also free and fully offline. Cloud AI features are optional and pay-per-use; there is no subscription.
+| Command | What it does |
+|---|---|
+| `mailtrim setup` | Guided first-time setup: connect Gmail or IMAP, run first scan |
+| `mailtrim quickstart` | One-shot scan → shows your safest first cleanup action |
+| `mailtrim stats` | Rank all senders by storage impact with confidence scores |
+| `mailtrim stats --since 30d` | Scope the scan to the last N days |
+| `mailtrim stats --share` | Generate a shareable summary (Twitter/plain) |
+| `mailtrim purge` | Interactive bulk delete — pick senders, confirm, done |
+| `mailtrim purge --domain example.com` | Target one domain directly |
+| `mailtrim purge --sort size` | Show largest senders first |
+| `mailtrim undo` | List recent operations and reverse any of them |
+| `mailtrim undo 3` | Reverse operation #3 specifically |
+| `mailtrim doctor` | Health check — auth, Gmail connection, storage, config |
+| `mailtrim sync` | Pull inbox into local cache for faster repeated queries |
+| `mailtrim unsubscribe email@sender.com` | Unsubscribe via List-Unsubscribe header |
 
----
+### Optional AI (requires `mailtrim config ai-mode cloud`)
 
-## 60-Second Quick Start
+| Command | What it does |
+|---|---|
+| `mailtrim triage` | Classify unread inbox — priority, category, why, suggested action |
+| `mailtrim bulk "archive newsletters older than 60 days"` | Natural language bulk operation |
+| `mailtrim avoid` | Surface emails you've viewed repeatedly but never acted on |
+| `mailtrim digest` | Weekly inbox summary — patterns, action items, one cleanup suggestion |
 
-Already have credentials.json from Google? This is all you need:
-
-```bash
-pip install mailtrim
-mailtrim auth        # opens browser once
-mailtrim quickstart  # guided first cleanup
-```
-
-Not set up yet? See the full setup below — it takes about 15 minutes once.
-
----
-
-## Safe by Default
-
-- **Everything goes to Trash first** — nothing is permanently deleted unless you explicitly use `--permanent` (hidden flag, requires a second confirmation flag)
-- **30-day undo window** — run `mailtrim undo` anytime to reverse any cleanup
-- **All data stays on your machine** — `~/.mailtrim/` only, no telemetry, no cloud sync
-- **Dry-run first** — most commands show you what they'd do before asking you to confirm
+### AI enrichment (local — no Anthropic key)
 
 ```bash
-mailtrim purge --domain linkedin.com   # shows what would be deleted, asks to confirm
-mailtrim undo                          # shows recent operations, pick one to reverse
-mailtrim doctor                        # checks auth, storage, and connection health
+mailtrim stats --ai-backend ollama --ai-model phi3   # requires Ollama
+mailtrim purge --ai-backend llama                     # requires llama.cpp at localhost:8080
 ```
 
 ---
 
-## Common Fixes
+## Setup
 
-If something isn't working, run:
-
-```bash
-mailtrim doctor
-```
-
-This checks auth, Gmail connection, storage, and optional AI — and tells you exactly what to fix.
-
-| Symptom | Fix |
-|---------|-----|
-| "Gmail connection expired" | `mailtrim auth` |
-| "Token file not found" | `mailtrim auth` |
-| "Cannot write to ~/.mailtrim/" | `chmod 700 ~/.mailtrim` |
-| "Rate limit hit" | Wait 60 seconds, retry with `--max-scan 300` |
-| Scan feels slow | Use `--max-scan 500` (default is 1000) |
-| Not seeing enough senders | Try `mailtrim stats --scope anywhere` |
-
----
-
-## Quick start (~20 minutes first time, ~30 seconds after)
-
-### 1. Install
+### Gmail (OAuth)
 
 ```bash
-git clone https://github.com/sadhgurutech/mailtrim
-cd mailtrim
-python3 -m venv venv && source venv/bin/activate
-pip install -e .
+# 1. Get credentials.json from Google Cloud Console (one-time, ~10 minutes)
+#    console.cloud.google.com → New project → Gmail API → OAuth 2.0 Client ID (Desktop)
+#    Download JSON → save to ~/.mailtrim/credentials.json
 
-# Optional: headless browser for near-100% unsubscribe success
-pip install -e ".[headless]" && playwright install chromium
-```
+# 2. Authenticate
+mailtrim auth    # opens browser once, stores token locally
 
-### 2. Get Gmail API credentials (one-time setup, ~15 minutes)
-
-This is a standard OAuth setup — you're authorising yourself to access your own inbox. Google never charges for this. You only do this once; after that, `mailtrim auth` refreshes your token automatically.
-
-> **Stuck?** The OAuth consent screen step trips up most people. When asked for "User type", choose **External**. Under "Test users", add your own Gmail address. That's it — you don't need to publish the app.
-
-1. Go to [console.cloud.google.com](https://console.cloud.google.com) → **New project**
-2. **APIs & Services** → **Enable APIs** → search **Gmail API** → Enable
-3. **OAuth consent screen** → External → add your Gmail as a **test user**
-4. **Credentials** → Create → **OAuth 2.0 Client ID** → Desktop app → Download JSON
-5. Save it: `mv ~/Downloads/client_secret_*.json ~/.mailtrim/credentials.json`
-
-> **Scopes requested:** `gmail.modify` (read, trash, label management) and `gmail.send` (follow-up drafts). `gmail.modify` grants the capability to read body content — mailtrim never does, but you should know the scope allows it.
-
-> **"This app isn't verified" warning:** Google shows this for any OAuth app that hasn't gone through their review process. It is expected and safe to proceed — you are authorising your own app to access your own inbox. Click **Advanced → Go to mailtrim (unsafe)** to continue.
-
-### 3. Authenticate
-
-```bash
-mailtrim auth
-# Opens browser → click Allow → done
-```
-
-### 4. See what's in your inbox
-
-```bash
+# 3. Run
 mailtrim stats
 ```
 
-**Sample output** *(illustrative — your numbers will vary)*:
-```
-Scan complete — 2,000 emails · 38 senders
+> **"This app isn't verified"** — expected. You're authorising your own app to access your own inbox. Click **Advanced → Go to mailtrim (unsafe)** to proceed.
 
-34% of your inbox is clutter — caused by just 3 senders. 87.4 MB gone in one command.
-
-TOTAL RECLAIMABLE SPACE
-  You can safely free ~87.4 MB (34.0% of scanned inbox)
-  from your top 3 senders · Each cleanup takes ~3-5s
-  All deletions go to Trash — undo anytime
-
- #  Impact         Sender                Emails  Size     Oldest       Risk
- 1  100 (High)     LinkedIn Jobs            312  44.0MB   847d ago     Safe to clean
- 2   82 (High)     Substack Weekly          183  26.1MB   512d ago     Safe to clean
- 3   51 (Medium)   GitHub Notifications     147   9.3MB    91d ago     Needs review
- 4   29 (Low)      Shopify                   94  12.2MB   203d ago     Safe to clean
- 5   18 (Low)      Medium Daily Digest       87  11.4MB   445d ago     Safe to clean
-
-Impact = 60% storage + 40% volume (0-100)
-```
-
-### 5. Bulk delete the offenders
+### IMAP (Outlook, Fastmail, iCloud, self-hosted)
 
 ```bash
-mailtrim purge
+mailtrim setup    # choose IMAP at the prompt — enter server, user, password
 ```
 
-**Sample output** *(illustrative)*:
-```
-  Top Email Offenders  (823 emails · 102.3 MB)
- # │ Sender                      │ Emails │ Size  │ Latest  │ Sample subject
-───┼─────────────────────────────┼────────┼───────┼─────────┼─────────────────────────────
- 1 │ LinkedIn Jobs <jobs@li...>  │   312  │  44MB │ Apr 03  │ 12 new jobs matching your...
- 2 │ Substack <hello@subst...>   │   183  │  26MB │ Apr 01  │ This week: AI is eating...
- 3 │ GitHub <noreply@github...>  │   147  │   9MB │ Apr 04  │ [myrepo] New issue opened...
-
-Select senders to delete.
-Enter numbers (1,3), ranges (1-5), all, or q to quit.
-
-Your selection: 1,2
-
-Selected 2 senders — 495 emails (70 MB):
-  ✕ LinkedIn Jobs (312 emails)
-  ✕ Substack (183 emails)
-
-Move 495 emails to Trash? (undo available for 30 days) [y/N]: y
-
-✓ Moved 495 emails to Trash. Undo log ID: 1 (mailtrim undo 1)
-```
-
-### 6. Share what you cleaned
+Or pass flags directly:
 
 ```bash
-mailtrim stats --share
-```
-
-The command outputs the following text, ready to copy and paste:
-
-```
-🤯 495 emails deleted · 87.4 MB freed in 8s using mailtrim
-   • 3 senders responsible
-   • Core cleanup runs locally — no API key needed
-   • My inbox was 34% clutter — now it's clean
-   • ~41 min of reading time reclaimed
-
-Free forever. → https://github.com/sadhgurutech/mailtrim
+mailtrim stats --provider imap --imap-server imap.fastmail.com --imap-user you@fastmail.com
+# Password: MAILTRIM_IMAP_PASSWORD env var, or prompted securely
 ```
 
 ---
 
-## All Commands
+## Confidence Scores
 
-### `quickstart` — Guided first cleanup *(no AI needed)*
+`purge` shows a 0–100 score that estimates how safe bulk-deletion is:
 
-```bash
-mailtrim quickstart   # checks auth, scans inbox, shows your first safe action
-```
+| Signal | Weight |
+|---|---|
+| `List-Unsubscribe` header present | 30 pts — sender self-identifies as bulk/marketing |
+| Age ≥ 180 days in inbox | up to 35 pts — emails sitting >6 months are rarely actionable |
+| Volume ≥ 50 from one sender | up to 35 pts — high frequency = almost certainly automated |
 
-![mailtrim quickstart](mailtrim/screenshots/quickstart.png)
+🟢 ≥70 Safe to clean · 🟡 40–69 Needs review · 🔴 Sensitive (bank, health, legal — never auto-suggested)
 
-### `doctor` — Health check
-
-```bash
-mailtrim doctor        # checks auth, Gmail, storage, config
-mailtrim doctor --ai   # also checks local AI endpoint
-```
-
-![mailtrim doctor](mailtrim/screenshots/doctor.png)
-
-### `stats` — Quick inbox overview *(no AI needed)*
-
-```bash
-mailtrim stats
-mailtrim stats --json                        # machine-readable output
-
-# Use with any IMAP account (Outlook, Fastmail, iCloud, self-hosted…)
-mailtrim stats --provider imap \
-  --imap-server imap.fastmail.com \
-  --imap-user you@fastmail.com
-# IMAP password is read from MAILTRIM_IMAP_PASSWORD env var or prompted securely
-
-# Enrich confidence scores with a local AI model (no Anthropic key needed)
-mailtrim stats --ai-backend ollama --ai-model phi3    # requires Ollama running
-mailtrim stats --ai-backend llama                      # requires llama.cpp at localhost:8080
-```
-
-![mailtrim stats](mailtrim/screenshots/stats.png)
-
-### `purge` — Bulk delete by sender *(no AI needed)*
-
-**How the Risk/Confidence score works:**
-
-Three signals combine to estimate how safe bulk-deletion is (0–100):
-
-| Signal | Weight | Logic |
-|--------|--------|-------|
-| `List-Unsubscribe` header present | 30 pts | Sender self-identifies as bulk/marketing |
-| Age ≥ 180 days in inbox | up to 35 pts | Emails sitting >6 months are rarely actionable |
-| Volume ≥ 50 from one sender | up to 35 pts | High frequency = almost certainly automated |
-
-🟢 ≥70 = Safe to clean · 🟡 40–69 = Needs review · 🔴 Sensitive / personal (bank, health, legal — never auto-deleted)
-
-Scores are heuristics — the 30-day undo exists precisely because no heuristic is perfect.
-
-```bash
-mailtrim purge                          # sort by email count (default)
-mailtrim purge --sort oldest            # show oldest clutter first
-mailtrim purge --sort size              # largest senders first
-mailtrim purge --query "older_than:1y"  # custom query
-mailtrim purge --unsub                  # also unsubscribe while deleting
-mailtrim purge --permanent              # skip Trash — IRREVERSIBLE
-mailtrim purge --json                   # output sender list as JSON
-
-# IMAP account
-mailtrim purge --provider imap --imap-server imap.outlook.com --imap-user you@outlook.com
-
-# Local AI enrichment
-mailtrim purge --ai-backend ollama --ai-model phi3
-```
-
-### `sync` — Pull inbox into local cache
-
-```bash
-mailtrim sync             # last 200 messages
-mailtrim sync --limit 500
-mailtrim sync --query "in:inbox is:unread"
-```
-
-### `triage` — AI inbox classification
-
-```bash
-mailtrim triage           # classify unread inbox
-mailtrim triage --limit 50
-```
-
-Every email gets: **priority** (high/medium/low) · **category** · **why** · **suggested action**
-
-### `bulk` — Natural language bulk operations
-
-```bash
-mailtrim bulk "archive all newsletters I haven't opened in 60 days"
-mailtrim bulk "delete all emails from noreply@* older than 1 year"
-mailtrim bulk "label receipts from order@ or receipt@ senders"
-mailtrim bulk "archive LinkedIn notifications" --dry-run  # preview first
-```
-
-### `undo` — Reverse a bulk operation (within 30 days)
-
-```bash
-mailtrim undo        # list recent operations
-mailtrim undo 42     # undo operation #42
-```
-
-### `follow-up` — Conditional follow-up tracking
-
-```bash
-mailtrim follow-up <message-id> --days 3   # remind only if no reply in 3 days
-mailtrim follow-up --list                   # see what's due today
-mailtrim follow-up --sync                   # check threads for replies
-```
-
-### `avoid` — Emails you keep putting off
-
-```bash
-mailtrim avoid                               # show with AI insight
-mailtrim avoid --no-insights                 # faster, no AI
-mailtrim avoid --process <id> --action archive
-```
-
-### `unsubscribe` — Unsubscribe that actually works
-
-```bash
-mailtrim unsubscribe newsletters@company.com
-mailtrim unsubscribe --from-query "label:newsletters" --limit 20
-mailtrim unsubscribe --history
-```
-
-### `rules` — Recurring automation
-
-```bash
-mailtrim rules --add "archive LinkedIn notifications older than 7 days"
-mailtrim rules --list
-mailtrim rules --run
-mailtrim rules --run --dry-run
-```
-
-### `digest` — Weekly inbox summary
-
-```bash
-mailtrim digest
-```
+Scores are heuristics. The 30-day undo exists precisely because no heuristic is perfect.
 
 ---
 
 ## Configuration
 
-All settings via environment variables or `~/.mailtrim/.env`:
+Settings via `~/.mailtrim/.env` or environment variables:
 
 | Variable | Default | Description |
-|----------|---------|-------------|
-| `ANTHROPIC_API_KEY` | *(not set)* | Anthropic API key. Without it, mock AI mode is used. |
-| `MAILTRIM_AI_MODEL` | `claude-sonnet-4-6` | Claude model for AI features |
-| `MAILTRIM_DRY_RUN` | `false` | Global dry-run (preview without executing) |
+|---|---|---|
+| `MAILTRIM_AI_MODE` | `off` | AI mode: `off` · `local` · `cloud` |
+| `ANTHROPIC_API_KEY` | *(not set)* | Required for cloud AI features |
+| `MAILTRIM_AI_MODEL` | `claude-sonnet-4-6` | Claude model for cloud AI |
+| `MAILTRIM_DRY_RUN` | `false` | Preview without executing |
 | `MAILTRIM_UNDO_WINDOW_DAYS` | `30` | How long undo logs are kept |
-| `MAILTRIM_AVOIDANCE_VIEW_THRESHOLD` | `3` | Views before an email is "avoided" |
-| `MAILTRIM_FOLLOW_UP_DEFAULT_DAYS` | `3` | Default follow-up window |
-| `MAILTRIM_DIR` | `~/.mailtrim` | Where tokens, DB, and config are stored |
-| `MAILTRIM_IMAP_PASSWORD` | *(not set)* | IMAP password for `--provider imap` (avoids interactive prompt) |
+| `MAILTRIM_DIR` | `~/.mailtrim` | Data directory |
+| `MAILTRIM_IMAP_PASSWORD` | *(not set)* | IMAP password (avoids interactive prompt) |
 
-**`~/.mailtrim/.env` example:**
-```
-ANTHROPIC_API_KEY=sk-ant-...
-MAILTRIM_DRY_RUN=false
-MAILTRIM_UNDO_WINDOW_DAYS=30
-```
+**Set AI mode:**
 
-> **Security note:** Restrict permissions on this file — `chmod 600 ~/.mailtrim/.env` — so only your user account can read the API key.
+```bash
+mailtrim config ai-mode off     # default — no AI, nothing sent anywhere
+mailtrim config ai-mode local   # local models only (Ollama, llama.cpp)
+mailtrim config ai-mode cloud   # Anthropic Claude — requires ANTHROPIC_API_KEY
+```
 
 ---
 
-## Testing (no credentials required)
+## Troubleshooting
 
 ```bash
-# Run all tests — zero API calls, zero credentials needed
-python -m pytest tests/ -v
-
-# With coverage
-python -m pytest tests/ --cov=mailtrim --cov-report=term-missing
+mailtrim doctor    # diagnoses auth, Gmail connection, storage, config
 ```
 
-All AI paths are covered by `MockAIEngine` — the full CLI can be exercised without any API key.
+| Symptom | Fix |
+|---|---|
+| "Gmail connection expired" | `mailtrim auth` |
+| "Token file not found" | `mailtrim auth` |
+| "Cannot write to ~/.mailtrim/" | `chmod 700 ~/.mailtrim` |
+| "Rate limit hit" | Wait 60s, retry with `--max-scan 300` |
+| Scan feels slow | `mailtrim stats --max-scan 500` |
+| Not seeing enough senders | `mailtrim stats --scope anywhere` |
+
+---
+
+## Testing
+
+```bash
+# Zero credentials required — all AI paths use MockAIEngine
+pytest tests/ -v
+```
 
 ---
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). Bug reports and feature requests welcome via [GitHub Issues](../../issues).
-
----
-
-## Architecture
-
-```
-mailtrim/
-├── config.py              # Settings (env vars, ~/.mailtrim/.env)
-├── core/
-│   ├── providers/
-│   │   ├── base.py        # EmailProvider ABC — 8-method interface
-│   │   ├── gmail.py       # Gmail implementation (OAuth + REST API)
-│   │   ├── imap.py        # IMAP implementation (stdlib only, SSL, batch fetch)
-│   │   └── factory.py     # get_provider("gmail"|"imap", ...) — selection point
-│   ├── ai/
-│   │   └── client.py      # AIClient ABC + LlamaCppClient + OllamaClient
-│   ├── gmail_client.py    # Gmail API: OAuth, CRUD, batching, retry on 429/5xx
-│   ├── storage.py         # Local SQLite: emails, follow-ups, rules, undo log
-│   ├── ai_engine.py       # Claude API: classify, NL→query, digest, avoidance
-│   ├── mock_ai.py         # Deterministic stub — full testing without API key
-│   ├── llm.py             # Local scoring engine: confidence, recommendations
-│   ├── follow_up.py       # Conditional follow-up: only surfaces if no reply
-│   ├── bulk_engine.py     # NL → dry-run preview → execute → 30-day undo
-│   ├── avoidance.py       # "Emails you avoid" detector + per-email AI insight
-│   ├── unsubscribe.py     # RFC 8058 one-click + mailto + Playwright headless
-│   ├── sender_stats.py    # Sender aggregation, risk classification, scoring
-│   ├── validation.py      # Input sanitization (query strings, user input)
-│   ├── diagnostics.py     # doctor command checks (auth, storage, connection)
-│   ├── errors.py          # Human-readable error translation layer
-│   └── usage_stats.py     # Local-only run metrics (never uploaded)
-└── cli/main.py            # Typer + Rich CLI — 15 commands
-```
+Bug reports and feature requests via [GitHub Issues](../../issues).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.
 
 ---
 
 ## License
 
-[MIT](LICENSE) — free to use, modify, and distribute.
+[MIT](LICENSE) — free to use, modify, distribute.

--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -80,6 +80,22 @@ def _print_ai_data_notice(what: str) -> None:
     )
 
 
+def _cloud_ai_warning() -> None:
+    """Print a prominent warning before any cloud AI call that may send email data."""
+    from rich.panel import Panel
+
+    console.print(
+        Panel(
+            "[bold yellow]⚠  Cloud AI is enabled[/bold yellow]\n"
+            "[dim]This command will send email subjects and/or snippets to Anthropic's servers.\n"
+            "No full email bodies are transmitted. See PRIVACY.md for details.\n\n"
+            "To disable:  [cyan]mailtrim config ai-mode off[/cyan][/dim]",
+            border_style="yellow",
+            padding=(0, 2),
+        )
+    )
+
+
 def _get_account_email(client) -> str:
     return client.get_email_address()
 
@@ -122,7 +138,10 @@ def _handle_error(exc: Exception, verbose: bool = False) -> None:
     from mailtrim.core.errors import friendly_error
 
     if isinstance(exc, AIModeError):
-        console.print(f"\n[yellow]AI blocked:[/yellow] {exc}")
+        lines = str(exc).strip().splitlines()
+        console.print(f"\n[bold yellow]AI blocked:[/bold yellow] {lines[0]}")
+        for line in lines[1:]:
+            console.print(f"  [dim]{line}[/dim]")
         raise typer.Exit(1)
 
     human_msg, fix_hint = friendly_error(exc)
@@ -741,6 +760,10 @@ def stats(
         console.print_json(json_lib.dumps(data))
         return
 
+    from mailtrim.core.ai.mode import ai_status_line
+
+    ai_label, ai_note, ai_color = ai_status_line(get_settings().ai_mode)
+
     first_run = _is_first_stats_run()
     console.print()
     if first_run:
@@ -754,6 +777,7 @@ def stats(
             f"[dim]  ✨ Scan complete — analyzed {insights.total_scanned:,} emails "
             f"across {insights.unique_senders} senders in {scan_elapsed}s{_since_note}[/dim]"
         )
+    console.print(f"  [{ai_color}]AI: {ai_label}[/{ai_color}]  [dim]{ai_note}[/dim]")
     console.print()
 
     # ── Headline Insight ──────────────────────────────────────────────────────
@@ -1294,6 +1318,13 @@ def quickstart():
             else ""
         )
     )
+
+    from mailtrim.core.ai.mode import ai_status_line
+
+    _qs_ai_label, _qs_ai_note, _qs_ai_color = ai_status_line(get_settings().ai_mode)
+    console.print(
+        f"  [{_qs_ai_color}]AI: {_qs_ai_label}[/{_qs_ai_color}]  [dim]{_qs_ai_note}[/dim]"
+    )
     console.print()
 
     # Step 3: Surface the single best safe action
@@ -1421,7 +1452,11 @@ def triage(
     """AI-powered inbox triage with explanations for every decision."""
     from mailtrim.core.ai.mode import require_cloud
 
-    require_cloud(get_settings().ai_mode)
+    try:
+        require_cloud(get_settings().ai_mode)
+    except Exception as exc:
+        _handle_error(exc)
+    _cloud_ai_warning()
     from mailtrim.core.avoidance import AvoidanceDetector
 
     client = _get_client()
@@ -1557,7 +1592,11 @@ def bulk(
     from mailtrim.core.ai.mode import require_cloud
     from mailtrim.core.bulk_engine import BulkEngine
 
-    require_cloud(get_settings().ai_mode)
+    try:
+        require_cloud(get_settings().ai_mode)
+    except Exception as exc:
+        _handle_error(exc)
+    _cloud_ai_warning()
     client = _get_client()
     account_email = _get_account_email(client)
     engine = BulkEngine(client, account_email, _get_ai())
@@ -1803,7 +1842,11 @@ def avoid(
     from mailtrim.core.ai.mode import require_cloud
     from mailtrim.core.avoidance import AvoidanceDetector
 
-    require_cloud(get_settings().ai_mode)
+    try:
+        require_cloud(get_settings().ai_mode)
+    except Exception as exc:
+        _handle_error(exc)
+    _cloud_ai_warning()
     client = _get_client()
     account_email = _get_account_email(client)
     detector = AvoidanceDetector(client, account_email, _get_ai())
@@ -2021,7 +2064,11 @@ def digest():
     """[EXPERIMENTAL] Generate your weekly inbox digest — insights, action items, and one cleanup suggestion."""
     from mailtrim.core.ai.mode import require_cloud
 
-    require_cloud(get_settings().ai_mode)
+    try:
+        require_cloud(get_settings().ai_mode)
+    except Exception as exc:
+        _handle_error(exc)
+    _cloud_ai_warning()
     from collections import Counter
 
     from mailtrim.core.avoidance import AvoidanceDetector
@@ -2856,6 +2903,15 @@ def doctor(
             console.print(f"     [dim]{r.message}[/dim]")
 
     console.print()
+
+    from mailtrim.core.ai.mode import ai_status_line
+
+    _dr_ai_label, _dr_ai_note, _dr_ai_color = ai_status_line(get_settings().ai_mode)
+    console.print(
+        f"  [{_dr_ai_color}]AI: {_dr_ai_label}[/{_dr_ai_color}]  [dim]{_dr_ai_note}[/dim]"
+    )
+    console.print()
+
     if required_fail == 0:
         status_text = "[bold green]Ready[/bold green]"
         border = "green"

--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -437,7 +437,13 @@ def auth(
         help="Path to OAuth credentials JSON downloaded from Google Cloud Console.",
     ),
 ):
-    """Authenticate with Gmail (opens browser for OAuth consent)."""
+    """
+    Authenticate with Gmail (opens browser for OAuth consent).
+
+    Examples:
+      mailtrim auth
+      mailtrim auth --credentials ~/Downloads/client_secret.json
+    """
     from mailtrim.core.gmail_client import authenticate
 
     console.print(
@@ -1262,6 +1268,10 @@ def quickstart():
     Guided first cleanup — checks auth, scans inbox, and suggests your first safe action.
 
     Perfect for first-time users. Run this before anything else.
+    All cleanups go to Trash — undo anytime with: mailtrim undo
+
+    Examples:
+      mailtrim quickstart
     """
     from mailtrim.core.sender_stats import (
         best_next_step,
@@ -1378,7 +1388,17 @@ def sync(
         help="Mail scope: 'inbox' (default) or 'anywhere' (includes archived, sent, all mail).",
     ),
 ):
-    """Sync mail metadata to local database."""
+    """
+    Sync mail metadata to local database for fast repeated queries.
+
+    Run before stats or triage when you want to avoid re-fetching from Gmail.
+
+    Examples:
+      mailtrim sync
+      mailtrim sync --limit 500
+      mailtrim sync --query "in:inbox is:unread"
+      mailtrim sync --scope anywhere
+    """
     from mailtrim.core.storage import EmailRecord, EmailRepo, get_session
 
     if scope == "anywhere" and query == "in:inbox":
@@ -1449,7 +1469,17 @@ def triage(
         True, "--actions/--no-actions", help="Show suggested actions."
     ),
 ):
-    """AI-powered inbox triage with explanations for every decision."""
+    """
+    AI-powered inbox triage — classifies each unread email with priority, category, and a one-line reason.
+
+    Requires ai_mode=cloud. Sends email subjects and snippets (≤300 chars) to Anthropic — never full body.
+    Run: mailtrim config ai-mode cloud
+
+    Examples:
+      mailtrim triage
+      mailtrim triage --limit 50
+      mailtrim triage --no-actions
+    """
     from mailtrim.core.ai.mode import require_cloud
 
     try:
@@ -1578,16 +1608,20 @@ def bulk(
     instruction: str = typer.Argument(
         ..., help='Natural language instruction, e.g. "archive all newsletters older than 30 days"'
     ),
-    dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Preview without making changes."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without making changes."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
 ):
     """
     Execute a bulk operation using natural language.
 
+    All destructive actions move email to Trash (recoverable for 30 days).
+    Requires ai_mode=cloud. Run: mailtrim config ai-mode cloud
+
     Examples:
       mailtrim bulk "archive all newsletters I haven't opened in 60 days"
-      mailtrim bulk "delete all emails from noreply@* older than 1 year"
+      mailtrim bulk "move to Trash all emails from noreply@* older than 1 year"
       mailtrim bulk "label as 'receipts' everything from order confirmation senders"
+      mailtrim bulk "archive LinkedIn notifications" --dry-run   # preview first
     """
     from mailtrim.core.ai.mode import require_cloud
     from mailtrim.core.bulk_engine import BulkEngine
@@ -1657,9 +1691,19 @@ def undo(
     log_id: Optional[int] = typer.Argument(
         None, help="Undo log ID. Omit to see recent operations."
     ),
-    yes: bool = typer.Option(False, "--yes", "-y"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
 ):
-    """Undo a bulk operation within the 30-day window."""
+    """
+    Undo a bulk operation within the 30-day window.
+
+    Restores emails from Trash back to their original location.
+    Each operation is identified by an ID shown at deletion time.
+
+    Examples:
+      mailtrim undo          # list all undoable operations
+      mailtrim undo 3        # restore operation #3
+      mailtrim undo 3 --yes  # restore without prompting
+    """
     from mailtrim.core.bulk_engine import BulkEngine
     from mailtrim.core.storage import UndoLogRepo, get_session
 
@@ -1755,7 +1799,7 @@ def follow_up(
     days: int = typer.Option(3, "--days", "-d", help="Remind in N days if no reply."),
     unconditional: bool = typer.Option(False, "--always", help="Remind even if they reply."),
     list_due: bool = typer.Option(False, "--list", "-l", help="Show due follow-ups."),
-    sync_replies: bool = typer.Option(False, "--sync", "-s", help="Sync reply detection."),
+    sync_replies: bool = typer.Option(False, "--sync", help="Sync reply detection."),
 ):
     """
     [EXPERIMENTAL] Track an email for follow-up. Only reminds you if they haven't replied.
@@ -1830,14 +1874,30 @@ def follow_up(
 @app.command()
 def avoid(
     process: Optional[str] = typer.Option(
-        None, "--process", "-p", help="Gmail ID to process (archive/delete)."
+        None, "--process", "-p", help="Gmail message ID to act on."
     ),
-    action: str = typer.Option("archive", "--action", "-a", help="Action: archive or delete."),
+    action: str = typer.Option(
+        "archive",
+        "--action",
+        "-a",
+        help="Action when processing: archive or trash (move to Trash — recoverable).",
+    ),
     no_insights: bool = typer.Option(False, "--no-insights", help="Skip AI insight generation."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would happen without acting."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
 ):
     """
     [EXPERIMENTAL] Show emails you've been putting off — viewed multiple times but never acted on.
     AI explains why you might be avoiding them and suggests one action.
+
+    Requires ai_mode=cloud. Run: mailtrim config ai-mode cloud
+    All Trash actions are recoverable for 30 days.
+
+    Examples:
+      mailtrim avoid
+      mailtrim avoid --no-insights              # faster, no AI
+      mailtrim avoid --process <id> --action archive
+      mailtrim avoid --process <id> --action trash  # move to Trash
     """
     from mailtrim.core.ai.mode import require_cloud
     from mailtrim.core.avoidance import AvoidanceDetector
@@ -1852,8 +1912,18 @@ def avoid(
     detector = AvoidanceDetector(client, account_email, _get_ai())
 
     if process:
-        detector.process(process, action)
-        console.print(f"[green]{action.capitalize()}d.[/green] Removed from avoidance list.")
+        action_display = "Move to Trash" if action == "trash" else action.capitalize()
+        if dry_run:
+            console.print(f"[dim]Dry run — would {action_display.lower()} message {process}.[/dim]")
+            return
+        if not yes:
+            if not Confirm.ask(f"{action_display} this email?"):
+                console.print("[dim]Cancelled.[/dim]")
+                return
+        effective_action = "delete" if action == "trash" else action
+        detector.process(process, effective_action)
+        result_msg = "Moved to Trash." if action == "trash" else f"{action.capitalize()}d."
+        console.print(f"[green]✓ {result_msg}[/green] Removed from avoidance list.")
         return
 
     if not no_insights:
@@ -1876,7 +1946,9 @@ def avoid(
         if ae.ai_insight:
             panel_content += f"[yellow]{ae.ai_insight}[/yellow]\n"
         panel_content += (
-            f"\n[dim]mailtrim avoid --process {ae.record.gmail_id} --action archive[/dim]"
+            f"\n[dim]mailtrim avoid --process {ae.record.gmail_id} --action archive[/dim]\n"
+            f"[dim]mailtrim avoid --process {ae.record.gmail_id} --action trash  "
+            "(move to Trash — recoverable)[/dim]"
         )
 
         console.print(Panel(panel_content, border_style="red", expand=False))
@@ -1889,17 +1961,29 @@ def avoid(
 def unsubscribe(
     sender: Optional[str] = typer.Argument(None, help="Sender email to unsubscribe from."),
     from_query: Optional[str] = typer.Option(
-        None, "--from-query", "-q", help="Gmail query to find senders."
+        None, "--from-query", "-q", help="Gmail query to find senders to unsubscribe from."
     ),
     no_headless: bool = typer.Option(
         False, "--no-headless", help="Skip Playwright headless fallback."
     ),
     list_history: bool = typer.Option(False, "--history", help="Show unsubscribe history."),
-    limit: int = typer.Option(10, "--limit", "-n"),
+    limit: int = typer.Option(10, "--limit", "-n", help="Max senders to process (default 10)."),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would be unsubscribed without acting."
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip per-sender confirmation prompt."),
 ):
     """
-    Unsubscribe from email senders using List-Unsubscribe headers + headless browser fallback.
-    Achieves near-100% success vs. the 70-85% of API-only tools.
+    Unsubscribe from email senders via List-Unsubscribe headers and headless browser fallback.
+
+    Uses RFC 8058 one-click unsubscribe when available; falls back to mailto and Playwright.
+    This action is irreversible — unsubscribing cannot be undone.
+
+    Examples:
+      mailtrim unsubscribe newsletters@example.com
+      mailtrim unsubscribe --from-query "label:newsletters" --limit 20
+      mailtrim unsubscribe --from-query "label:newsletters" --dry-run   # preview first
+      mailtrim unsubscribe --history
     """
     from mailtrim.core.unsubscribe import UnsubscribeEngine
 
@@ -1946,14 +2030,26 @@ def unsubscribe(
                         seen_senders.add(msg.sender_email)
                         messages.append(msg)
     else:
-        console.print("Provide a sender email or --from-query.")
+        console.print("[red]Error:[/red] Provide a sender email or --from-query.")
+        console.print("  [dim]Example: mailtrim unsubscribe newsletters@example.com[/dim]")
         raise typer.Exit(1)
 
     if not messages:
         console.print("[yellow]No messages found.[/yellow]")
         return
 
+    if dry_run:
+        console.print(f"[dim]Dry run — would unsubscribe from {len(messages)} sender(s):[/dim]")
+        for msg in messages:
+            console.print(f"  [dim]· {msg.sender_email}[/dim]")
+        console.print("[dim]Remove --dry-run to execute.[/dim]")
+        return
+
     for msg in messages:
+        if not yes:
+            if not Confirm.ask(f"Unsubscribe from [bold]{msg.sender_email}[/bold]?"):
+                console.print("[dim]Skipped.[/dim]")
+                continue
         console.print(f"Unsubscribing from [bold]{msg.sender_email}[/bold]...", end=" ")
         result = engine.unsubscribe(msg, use_headless=not no_headless)
         status = "[green]success[/green]" if result.success else "[red]failed[/red]"
@@ -1970,7 +2066,9 @@ def rules(
     run: bool = typer.Option(False, "--run", "-r", help="Run all active rules now."),
     list_rules: bool = typer.Option(False, "--list", "-l", help="List all active rules."),
     remove_id: Optional[int] = typer.Option(None, "--remove", help="Deactivate a rule by ID."),
-    dry_run: bool = typer.Option(False, "--dry-run", "-n"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview rule execution without making changes."
+    ),
 ):
     """
     Manage recurring automation rules defined in natural language.
@@ -2061,7 +2159,15 @@ def rules(
 
 @app.command()
 def digest():
-    """[EXPERIMENTAL] Generate your weekly inbox digest — insights, action items, and one cleanup suggestion."""
+    """
+    [EXPERIMENTAL] Generate your weekly inbox digest — insights, action items, and one cleanup suggestion.
+
+    Requires ai_mode=cloud. Sends inbox counts and sender names to Anthropic — no subjects or body content.
+    Run: mailtrim config ai-mode cloud
+
+    Examples:
+      mailtrim digest
+    """
     from mailtrim.core.ai.mode import require_cloud
 
     try:
@@ -2203,12 +2309,12 @@ def purge(
     keep: Optional[int] = typer.Option(
         None,
         "--keep",
-        help="Keep the last N emails per sender; delete the rest.",
+        help="Keep the last N emails per sender; move the rest to Trash (recoverable).",
     ),
     older_than: Optional[int] = typer.Option(
         None,
         "--older-than",
-        help="Only delete emails older than this many days.",
+        help="Only move to Trash emails older than this many days.",
     ),
     max_scan: int = typer.Option(2000, "--max-scan", help="Max emails to scan."),
     top: int = typer.Option(30, "--top", "-n", help="How many top offenders to show."),
@@ -2244,7 +2350,7 @@ def purge(
     use_ai: bool = typer.Option(
         False,
         "--ai",
-        help="Adjust confidence scores with local AI signal (requires llama.cpp at localhost:8080).",
+        help="[EXPERIMENTAL] Enrich confidence scores with local AI (requires llama.cpp at localhost:8080).",
     ),
     provider: str = typer.Option("gmail", "--provider", help="Email provider: gmail or imap."),
     imap_server: str = typer.Option("", "--imap-server", help="IMAP server hostname."),
@@ -2254,7 +2360,9 @@ def purge(
         "INBOX", "--imap-folder", help="IMAP folder to scan (default INBOX)."
     ),
     ai_backend: str = typer.Option(
-        "llama", "--ai-backend", help="Local AI backend: llama or ollama."
+        "llama",
+        "--ai-backend",
+        help="Local AI backend: llama (llama.cpp, default) or ollama.",
     ),
     ai_url: str = typer.Option("", "--ai-url", help="Override local AI server URL."),
     ai_model: str = typer.Option("phi3", "--ai-model", help="Model name (Ollama only)."),

--- a/mailtrim/core/ai/mode.py
+++ b/mailtrim/core/ai/mode.py
@@ -62,3 +62,18 @@ def require_cloud(mode: str) -> None:
             "To allow external calls:  mailtrim config ai-mode cloud\n"
             "Warning: cloud mode sends email subjects and snippets to Anthropic."
         )
+
+
+def ai_status_line(mode: str) -> tuple[str, str, str]:
+    """Return (label, note, color) for displaying AI mode in CLI output.
+
+    Usage::
+
+        label, note, color = ai_status_line(get_settings().ai_mode)
+        console.print(f"  [{color}]AI: {label}[/{color}]  [dim]{note}[/dim]")
+    """
+    if mode == "local":
+        return ("LOCAL", "runs on your machine — nothing sent externally", "cyan")
+    if mode == "cloud":
+        return ("CLOUD", "email data may be sent to Anthropic", "yellow")
+    return ("OFF", "no data leaves your machine", "green")

--- a/mailtrim/core/sender_stats.py
+++ b/mailtrim/core/sender_stats.py
@@ -507,6 +507,82 @@ def generate_share_text(
 
 _REPO_URL = "https://github.com/sadhgurutech/mailtrim"
 
+# Substrings that indicate a domain carries sensitive content.
+# Domains matching any of these are silently excluded from share text.
+_SENSITIVE_DOMAIN_PATTERNS: tuple[str, ...] = (
+    "bank",
+    "paypal",
+    "venmo",
+    "zelle",
+    "financial",
+    "credit",
+    "loan",
+    "mortgage",
+    "insurance",
+    "brokerage",
+    "fidelity",
+    "vanguard",
+    "schwab",
+    "health",
+    "medical",
+    "hospital",
+    "pharmacy",
+    "prescription",
+    "clinic",
+    ".gov",
+    "irs.",
+    "legal",
+    "lawyer",
+    "attorney",
+    "court",
+    "crypto",
+    "bitcoin",
+    "wallet",
+)
+
+# Human-readable labels for well-known domains.
+# Unlisted domains fall back to their raw domain name.
+_DOMAIN_PRETTY: dict[str, str] = {
+    "linkedin.com": "LinkedIn",
+    "github.com": "GitHub",
+    "substack.com": "Substack",
+    "medium.com": "Medium",
+    "twitter.com": "Twitter",
+    "x.com": "X",
+    "facebook.com": "Facebook",
+    "instagram.com": "Instagram",
+    "youtube.com": "YouTube",
+    "google.com": "Google",
+    "amazon.com": "Amazon",
+    "netflix.com": "Netflix",
+    "slack.com": "Slack",
+    "notion.so": "Notion",
+    "shopify.com": "Shopify",
+    "hubspot.com": "HubSpot",
+    "mailchimp.com": "Mailchimp",
+    "glassdoor.com": "Glassdoor",
+    "indeed.com": "Indeed",
+    "spotify.com": "Spotify",
+    "twitch.tv": "Twitch",
+    "reddit.com": "Reddit",
+    "quora.com": "Quora",
+    "duolingo.com": "Duolingo",
+    "zoom.us": "Zoom",
+    "dropbox.com": "Dropbox",
+    "figma.com": "Figma",
+}
+
+
+def _is_sensitive_domain(domain: str) -> bool:
+    """Return True when a domain name matches any sensitive content pattern."""
+    d = domain.lower()
+    return any(pat in d for pat in _SENSITIVE_DOMAIN_PATTERNS)
+
+
+def _prettify_domain(domain: str) -> str:
+    """Return a human-readable label for a domain (e.g. 'linkedin.com' → 'LinkedIn')."""
+    return _DOMAIN_PRETTY.get(domain.lower(), domain)
+
 
 def generate_stats_share_text(
     reclaimable_mb_val: float,
@@ -517,50 +593,60 @@ def generate_stats_share_text(
     fmt: str = "twitter",
 ) -> str:
     """
-    Share text for ``mailtrim stats --share`` — describes what *could* be cleaned,
-    not what has been cleaned (that's generate_share_text / generate_viral_share_text).
+    Share text for ``mailtrim stats --share`` — describes what *could* be cleaned.
 
-    ``fmt`` is "twitter" (emoji, ≤280 chars) or "plain" (no emoji, plain ASCII).
+    Format
+    ------
+    Line 1 — the core stat: email count · MB (if > 0) · N senders · scan speed (if > 0)
+    Line 2 — top 1–2 safe sources in human-readable labels (omitted when none)
+    Line 3 — short CTA with repo URL
 
-    No personal data: no email addresses, no account name.
-    Top domains are the category-level source names (linkedin.com, github.com…).
+    Rules
+    -----
+    * ``fmt="twitter"``: leads with 🧹, targets ≤200 chars (hard cap 280).
+    * ``fmt="plain"``: no emoji, plain ASCII.
+    * Sensitive domains (bank, health, gov …) are silently excluded.
+    * No personal data — no email addresses, no account name.
+    * When total length would exceed 200 chars the sources line is dropped first.
     """
     sender_word = "sender" if sender_count == 1 else "senders"
     email_str = f"{email_count:,}"
-    mb_str = f"{reclaimable_mb_val} MB" if reclaimable_mb_val > 0 else ""
-    size_part = f" · {mb_str}" if mb_str else ""
-    speed_part = f" — scanned in {scan_seconds}s" if scan_seconds > 0 else ""
 
-    # Top 3 domains only; drop empty strings
-    top = [d for d in top_domains[:3] if d]
-    sources_line = f"Top sources: {', '.join(top)}" if top else ""
+    size_part = f" · {reclaimable_mb_val} MB" if reclaimable_mb_val > 0 else ""
+    speed_part = f". Scanned in {scan_seconds}s" if scan_seconds > 0 else ""
+
+    # Top 1-2 non-sensitive sources with human-readable labels
+    safe_labels = [_prettify_domain(d) for d in top_domains if d and not _is_sensitive_domain(d)][
+        :2
+    ]
+    sources_label = " & ".join(safe_labels) if safe_labels else ""
 
     if fmt == "plain":
-        first_line = (
-            f"Found {email_str} emails to clean from {sender_count} {sender_word}"
-            f"{size_part}{speed_part}"
-        )
-        parts = [first_line]
-        if sources_line:
-            parts.append(sources_line)
+        stat_line = f"{email_str} emails{size_part} — {sender_count} {sender_word}{speed_part}"
+        parts = [stat_line]
+        if sources_label:
+            parts.append(f"Top sources: {sources_label}")
         parts.append(_REPO_URL)
         return "\n".join(parts)
 
-    # twitter format — emoji, punchy, ≤280 chars
-    first_line = (
-        f"🧹 {email_str} emails to clean · {sender_count} {sender_word}{size_part}{speed_part}"
-    )
-    cta = f"Free & open-source → {_REPO_URL}"
-    parts = [first_line]
-    if sources_line:
-        parts.append(sources_line)
+    # twitter — emoji, punchy
+    stat_line = f"🧹 {email_str} emails{size_part} — {sender_count} {sender_word}{speed_part}"
+    cta = f"Free → {_REPO_URL}"
+
+    parts = [stat_line]
+    if sources_label:
+        parts.append(f"Top: {sources_label}")
     parts.append(cta)
     text = "\n".join(parts)
 
-    # Safety truncation: trim sources line if over 280 (rare but possible)
+    # Prefer ≤200 chars: drop sources line if needed
+    if len(text) > 200 and sources_label:
+        text = "\n".join([stat_line, cta])
+
+    # Hard cap at 280: shorten stat line as last resort
     if len(text) > 280:
-        parts_no_sources = [first_line, cta]
-        text = "\n".join(parts_no_sources)
+        stat_line = f"🧹 {email_str} emails{size_part} — {sender_count} {sender_word}"
+        text = "\n".join([stat_line, cta])
 
     return text
 

--- a/mailtrim/core/storage.py
+++ b/mailtrim/core/storage.py
@@ -16,7 +16,8 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
-from mailtrim.config import DB_PATH, get_settings
+import mailtrim.config as _cfg
+from mailtrim.config import get_settings
 
 # ── Base ─────────────────────────────────────────────────────────────────────
 
@@ -198,7 +199,7 @@ def get_engine():
     global _engine
     if _engine is None:
         _engine = create_engine(
-            f"sqlite:///{DB_PATH}",
+            f"sqlite:///{_cfg.DB_PATH}",
             connect_args={"check_same_thread": False},
             echo=False,
         )

--- a/mailtrim/core/storage.py
+++ b/mailtrim/core/storage.py
@@ -17,7 +17,6 @@ from sqlalchemy import (
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 import mailtrim.config as _cfg
-from mailtrim.config import get_settings
 
 # ── Base ─────────────────────────────────────────────────────────────────────
 
@@ -251,7 +250,7 @@ class EmailRepo:
 
     def find_avoided(self, account_email: str, threshold: int | None = None) -> list[EmailRecord]:
         """Emails viewed >= threshold times but not acted on."""
-        t = threshold or get_settings().avoidance_view_threshold
+        t = threshold or _cfg.get_settings().avoidance_view_threshold
         return (
             self.s.query(EmailRecord)
             .filter(
@@ -336,7 +335,7 @@ class UndoLogRepo:
     ) -> UndoLogEntry:
         from datetime import timedelta
 
-        settings = get_settings()
+        settings = _cfg.get_settings()
         entry = UndoLogEntry(
             account_email=account_email,
             operation=operation,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Shared pytest fixtures for the mailtrim test suite.
+
+``clean_db``  — provides an isolated in-memory SQLite database for every test
+that touches the storage layer.  Using in-memory SQLite means:
+
+* No file-system side effects — nothing written to ~/.mailtrim
+* Each test starts with an empty schema — zero shared state between tests
+* No dependency on cfg.DB_PATH or MAILTRIM_DIR environment variables
+
+Usage
+-----
+Add ``clean_db`` to any test function or class that calls
+``get_session()``, ``BlocklistRepo``, ``EmailRepo``, etc.
+
+To apply automatically to all tests in a module, add an autouse fixture
+that depends on ``clean_db``::
+
+    @pytest.fixture(autouse=True)
+    def _use_clean_db(clean_db):
+        pass
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+@pytest.fixture()
+def clean_db(monkeypatch):
+    """Inject a fresh in-memory SQLite engine into the storage module.
+
+    Resets ``_engine`` and ``_SessionLocal`` to a brand-new in-memory
+    database before the test and restores the originals (via monkeypatch)
+    after it completes — regardless of whether the test passes or fails.
+    """
+    import mailtrim.core.storage as storage
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        echo=False,
+    )
+    storage.Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+
+    monkeypatch.setattr(storage, "_engine", engine)
+    monkeypatch.setattr(storage, "_SessionLocal", session_factory)
+
+    yield engine
+
+    engine.dispose()

--- a/tests/test_ai_trust_boundary.py
+++ b/tests/test_ai_trust_boundary.py
@@ -119,6 +119,7 @@ class TestStatsBadge:
         with (
             patch("mailtrim.cli.main._get_provider", return_value=mock_client),
             patch("mailtrim.core.sender_stats.fetch_sender_groups", return_value=[]),
+            patch("mailtrim.cli.main._record"),
             patch(
                 "mailtrim.cli.main.get_settings",
                 return_value=MagicMock(ai_mode=mode),
@@ -167,7 +168,7 @@ class TestQuickstartBadge:
         }
 
         with (
-            patch("mailtrim.cli.main._get_provider", return_value=mock_client),
+            patch("mailtrim.cli.main._get_client", return_value=mock_client),
             patch("mailtrim.core.sender_stats.fetch_sender_groups", return_value=[]),
             patch(
                 "mailtrim.cli.main.get_settings",

--- a/tests/test_ai_trust_boundary.py
+++ b/tests/test_ai_trust_boundary.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -232,6 +233,10 @@ class TestDoctorBadge:
 
 
 class TestCloudWarning:
+    @pytest.fixture(autouse=True)
+    def _use_clean_db(self, clean_db):
+        """Provide an in-memory DB so bulk/avoid/digest don't fail on missing DB dir."""
+
     def _invoke_with_cloud_mode(self, command: list[str]):
         """
         Stub out the command's heavy work but let require_cloud + _cloud_ai_warning run.

--- a/tests/test_ai_trust_boundary.py
+++ b/tests/test_ai_trust_boundary.py
@@ -1,0 +1,322 @@
+"""Tests for the AI trust boundary system.
+
+Covers:
+- ai_status_line() output for all three modes
+- AIModeError formatting in _handle_error
+- AI badge visible in stats, quickstart, doctor output
+- Cloud AI warning panel shown before triage/bulk/avoid/digest
+- Off-mode blocking with actionable message
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+# ── ai_status_line unit tests ─────────────────────────────────────────────────
+
+
+class TestAiStatusLine:
+    def _s(self, mode: str):
+        from mailtrim.core.ai.mode import ai_status_line
+
+        return ai_status_line(mode)
+
+    def test_off_label(self):
+        label, _, _ = self._s("off")
+        assert label == "OFF"
+
+    def test_off_note_mentions_no_data_leaves(self):
+        _, note, _ = self._s("off")
+        assert "no data leaves" in note
+
+    def test_off_color_is_green(self):
+        _, _, color = self._s("off")
+        assert color == "green"
+
+    def test_local_label(self):
+        label, _, _ = self._s("local")
+        assert label == "LOCAL"
+
+    def test_local_note_mentions_machine(self):
+        _, note, _ = self._s("local")
+        assert "machine" in note
+
+    def test_local_color_is_cyan(self):
+        _, _, color = self._s("local")
+        assert color == "cyan"
+
+    def test_cloud_label(self):
+        label, _, _ = self._s("cloud")
+        assert label == "CLOUD"
+
+    def test_cloud_note_mentions_anthropic(self):
+        _, note, _ = self._s("cloud")
+        assert "Anthropic" in note
+
+    def test_cloud_color_is_yellow(self):
+        _, _, color = self._s("cloud")
+        assert color == "yellow"
+
+
+# ── _handle_error AIModeError formatting ────────────────────────────────────
+
+
+class TestHandleErrorAIModeError:
+    def _invoke_triage_with_off(self):
+        """Invoke triage with ai_mode=off so require_cloud raises AIModeError."""
+        from mailtrim.cli.main import app
+
+        mock_client = MagicMock()
+
+        with (
+            patch("mailtrim.cli.main._get_client", return_value=mock_client),
+            patch(
+                "mailtrim.cli.main.get_settings",
+                return_value=MagicMock(ai_mode="off"),
+            ),
+        ):
+            return runner.invoke(app, ["triage"], catch_exceptions=False)
+
+    def test_off_mode_exits_1(self):
+        result = self._invoke_triage_with_off()
+        assert result.exit_code == 1
+
+    def test_off_mode_prints_ai_blocked(self):
+        result = self._invoke_triage_with_off()
+        assert "AI blocked" in result.output
+
+    def test_off_mode_shows_enable_command(self):
+        result = self._invoke_triage_with_off()
+        assert "mailtrim config ai-mode" in result.output
+
+    def test_multiline_error_shows_secondary_lines(self):
+        """Each line of AIModeError.message is printed, not just the first."""
+        result = self._invoke_triage_with_off()
+        # The full message has 3 lines; check at least one secondary line appears
+        flat = result.output.replace("\n", " ")
+        assert "ai-mode" in flat.lower()
+
+
+# ── AI badge in stats output ──────────────────────────────────────────────────
+
+
+class TestStatsBadge:
+    def _invoke_stats(self, mode: str = "off"):
+        from mailtrim.cli.main import app
+
+        mock_client = MagicMock()
+        mock_client.get_profile.return_value = {
+            "emailAddress": "user@gmail.com",
+            "messagesTotal": 0,
+            "threadsTotal": 0,
+        }
+
+        with (
+            patch("mailtrim.cli.main._get_provider", return_value=mock_client),
+            patch("mailtrim.core.sender_stats.fetch_sender_groups", return_value=[]),
+            patch(
+                "mailtrim.cli.main.get_settings",
+                return_value=MagicMock(ai_mode=mode),
+            ),
+        ):
+            return runner.invoke(app, ["stats"], catch_exceptions=False)
+
+    def test_stats_shows_ai_badge(self):
+        result = self._invoke_stats("off")
+        assert result.exit_code == 0
+        assert "AI:" in result.output
+
+    def test_stats_off_mode_shows_off_label(self):
+        result = self._invoke_stats("off")
+        assert "OFF" in result.output
+
+    def test_stats_off_mode_shows_no_data_leaves(self):
+        result = self._invoke_stats("off")
+        assert "no data leaves" in result.output
+
+    def test_stats_local_mode_shows_local_label(self):
+        result = self._invoke_stats("local")
+        assert "LOCAL" in result.output
+
+    def test_stats_cloud_mode_shows_cloud_label(self):
+        result = self._invoke_stats("cloud")
+        assert "CLOUD" in result.output
+
+    def test_stats_cloud_mode_mentions_anthropic(self):
+        result = self._invoke_stats("cloud")
+        assert "Anthropic" in result.output
+
+
+# ── AI badge in quickstart output ────────────────────────────────────────────
+
+
+class TestQuickstartBadge:
+    def _invoke_quickstart(self, mode: str = "off"):
+        from mailtrim.cli.main import app
+
+        mock_client = MagicMock()
+        mock_client.get_profile.return_value = {
+            "emailAddress": "user@gmail.com",
+            "messagesTotal": 0,
+            "threadsTotal": 0,
+        }
+
+        with (
+            patch("mailtrim.cli.main._get_provider", return_value=mock_client),
+            patch("mailtrim.core.sender_stats.fetch_sender_groups", return_value=[]),
+            patch(
+                "mailtrim.cli.main.get_settings",
+                return_value=MagicMock(ai_mode=mode),
+            ),
+        ):
+            return runner.invoke(app, ["quickstart"], catch_exceptions=False)
+
+    def test_quickstart_shows_ai_badge(self):
+        result = self._invoke_quickstart("off")
+        assert result.exit_code == 0
+        assert "AI:" in result.output
+
+    def test_quickstart_off_shows_off(self):
+        result = self._invoke_quickstart("off")
+        assert "OFF" in result.output
+
+    def test_quickstart_local_shows_local(self):
+        result = self._invoke_quickstart("local")
+        assert "LOCAL" in result.output
+
+    def test_quickstart_cloud_mentions_anthropic(self):
+        result = self._invoke_quickstart("cloud")
+        assert "Anthropic" in result.output
+
+
+# ── AI badge in doctor output ────────────────────────────────────────────────
+
+
+class TestDoctorBadge:
+    def _invoke_doctor(self, mode: str = "off"):
+        from mailtrim.cli.main import app
+        from mailtrim.core.diagnostics import CheckResult
+
+        ok_results = [CheckResult("Auth token valid", ok=True, message="ok")]
+
+        with (
+            patch("mailtrim.core.diagnostics.run_all", return_value=ok_results),
+            patch(
+                "mailtrim.cli.main.get_settings",
+                return_value=MagicMock(ai_mode=mode),
+            ),
+        ):
+            return runner.invoke(app, ["doctor"], catch_exceptions=False)
+
+    def test_doctor_shows_ai_badge(self):
+        result = self._invoke_doctor("off")
+        assert result.exit_code == 0
+        assert "AI:" in result.output
+
+    def test_doctor_off_shows_off_label(self):
+        result = self._invoke_doctor("off")
+        assert "OFF" in result.output
+
+    def test_doctor_cloud_shows_cloud_label(self):
+        result = self._invoke_doctor("cloud")
+        assert "CLOUD" in result.output
+
+
+# ── Cloud warning panel for AI commands ────────────────────────────────────
+
+
+class TestCloudWarning:
+    def _invoke_with_cloud_mode(self, command: list[str]):
+        """
+        Stub out the command's heavy work but let require_cloud + _cloud_ai_warning run.
+        """
+        from mailtrim.cli.main import app
+
+        mock_client = MagicMock()
+        mock_client.get_email_address.return_value = "user@gmail.com"
+        mock_client.list_message_ids.return_value = []
+        mock_client.get_messages_batch.return_value = []
+
+        with (
+            patch("mailtrim.cli.main._get_client", return_value=mock_client),
+            patch("mailtrim.cli.main._get_provider", return_value=mock_client),
+            patch(
+                "mailtrim.cli.main.get_settings",
+                return_value=MagicMock(ai_mode="cloud"),
+            ),
+        ):
+            return runner.invoke(app, command, catch_exceptions=False)
+
+    def test_triage_shows_cloud_warning(self):
+        result = self._invoke_with_cloud_mode(["triage"])
+        assert "Cloud AI is enabled" in result.output
+
+    def test_bulk_shows_cloud_warning(self):
+        result = self._invoke_with_cloud_mode(["bulk", "delete old newsletters"])
+        assert "Cloud AI is enabled" in result.output
+
+    def test_avoid_shows_cloud_warning(self):
+        result = self._invoke_with_cloud_mode(["avoid"])
+        assert "Cloud AI is enabled" in result.output
+
+    def test_digest_shows_cloud_warning(self):
+        result = self._invoke_with_cloud_mode(["digest"])
+        assert "Cloud AI is enabled" in result.output
+
+    def test_triage_warning_mentions_anthropic(self):
+        result = self._invoke_with_cloud_mode(["triage"])
+        assert "Anthropic" in result.output
+
+    def test_triage_warning_mentions_disable(self):
+        result = self._invoke_with_cloud_mode(["triage"])
+        assert "mailtrim config ai-mode off" in result.output
+
+
+# ── Off-mode blocking ─────────────────────────────────────────────────────────
+
+
+class TestOffModeBlocking:
+    def _invoke_cloud_cmd_with_off(self, command: list[str]):
+        from mailtrim.cli.main import app
+
+        mock_client = MagicMock()
+
+        with (
+            patch("mailtrim.cli.main._get_client", return_value=mock_client),
+            patch("mailtrim.cli.main._get_provider", return_value=mock_client),
+            patch(
+                "mailtrim.cli.main.get_settings",
+                return_value=MagicMock(ai_mode="off"),
+            ),
+        ):
+            return runner.invoke(app, command, catch_exceptions=False)
+
+    def test_triage_off_exits_1(self):
+        result = self._invoke_cloud_cmd_with_off(["triage"])
+        assert result.exit_code == 1
+
+    def test_bulk_off_exits_1(self):
+        result = self._invoke_cloud_cmd_with_off(["bulk", "delete old mail"])
+        assert result.exit_code == 1
+
+    def test_avoid_off_exits_1(self):
+        result = self._invoke_cloud_cmd_with_off(["avoid"])
+        assert result.exit_code == 1
+
+    def test_digest_off_exits_1(self):
+        result = self._invoke_cloud_cmd_with_off(["digest"])
+        assert result.exit_code == 1
+
+    def test_triage_off_shows_enable_hint(self):
+        result = self._invoke_cloud_cmd_with_off(["triage"])
+        assert "mailtrim config ai-mode" in result.output
+
+    def test_bulk_off_no_cloud_warning(self):
+        """_cloud_ai_warning must NOT fire when mode is off (blocked before reaching it)."""
+        result = self._invoke_cloud_cmd_with_off(["bulk", "delete old mail"])
+        assert "Cloud AI is enabled" not in result.output

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -129,18 +129,22 @@ def _invoke_imap(groups=None, imap_ok=True):
 
     from mailtrim.core.diagnostics import CheckResult
 
+    ok = CheckResult("ok", ok=True, message="ok")
     check_results = [
         CheckResult("Required packages", ok=True, message="ok"),
         CheckResult("Config", ok=True, message="ok"),
         CheckResult("Data directory", ok=True, message="ok"),
         CheckResult("Undo storage", ok=True, message="ok"),
     ]
-
     imap_input = "I\nimap.example.com\nuser@example.com\nsecret\n993\n"
     with (
         patch("pathlib.Path.exists", return_value=True),
         patch("mailtrim.core.providers.factory.get_provider", return_value=mock_provider),
         patch("mailtrim.core.diagnostics.run_all", return_value=check_results),
+        patch("mailtrim.core.diagnostics.check_dependencies", return_value=ok),
+        patch("mailtrim.core.diagnostics.check_config", return_value=ok),
+        patch("mailtrim.core.diagnostics.check_data_dir", return_value=ok),
+        patch("mailtrim.core.diagnostics.check_undo_storage", return_value=ok),
         patch("mailtrim.core.sender_stats.fetch_sender_groups", return_value=groups),
     ):
         return runner.invoke(app, ["setup"], input=imap_input, catch_exceptions=False)

--- a/tests/test_smarter_confidence.py
+++ b/tests/test_smarter_confidence.py
@@ -4,31 +4,12 @@ from datetime import datetime, timezone
 
 import pytest
 
-# ── Fixtures ─────────────────────────────────────────────────────────────────
+# ── DB isolation ──────────────────────────────────────────────────────────────
 
 
 @pytest.fixture(autouse=True)
-def isolated_db(monkeypatch, tmp_path):
-    """Redirect all storage to a temp dir so tests never touch ~/.mailtrim."""
-    monkeypatch.setenv("MAILTRIM_DIR", str(tmp_path))
-    import mailtrim.config as cfg
-
-    cfg._settings = None
-    cfg.DATA_DIR = tmp_path
-    cfg.DB_PATH = tmp_path / "test.db"
-    cfg.UNDO_LOG_DIR = tmp_path / "undo_logs"
-
-    import mailtrim.core.storage as storage
-
-    storage._engine = None
-    storage._SessionLocal = None
-
-    yield
-
-    if storage._engine:
-        storage._engine.dispose()
-    storage._engine = None
-    storage._SessionLocal = None
+def _use_clean_db(clean_db):
+    """Apply the shared in-memory DB fixture to every test in this module."""
 
 
 def _make_group(

--- a/tests/test_stats_share.py
+++ b/tests/test_stats_share.py
@@ -54,6 +54,7 @@ def _invoke(*args: str, groups=None):
     with (
         patch("mailtrim.cli.main._get_provider", return_value=mock_client),
         patch("mailtrim.core.sender_stats.fetch_sender_groups", return_value=groups),
+        patch("mailtrim.cli.main._record"),
     ):
         return runner.invoke(app, ["stats", *args], catch_exceptions=False)
 

--- a/tests/test_stats_share.py
+++ b/tests/test_stats_share.py
@@ -150,7 +150,8 @@ class TestGenerateStatsShareText:
         )
         assert "MB" not in text
 
-    def test_contains_top_domains(self):
+    def test_contains_top_domains_as_pretty_labels(self):
+        """Known domains are displayed as human-readable labels, not raw domain names."""
         from mailtrim.core.sender_stats import generate_stats_share_text
 
         text = generate_stats_share_text(
@@ -160,8 +161,12 @@ class TestGenerateStatsShareText:
             top_domains=["linkedin.com", "github.com"],
             scan_seconds=2,
         )
-        assert "linkedin.com" in text
-        assert "github.com" in text
+        assert "LinkedIn" in text
+        assert "GitHub" in text
+        # linkedin.com cannot appear in the URL — absence confirms prettification worked
+        assert "linkedin.com" not in text
+        # Sources line is present using pretty labels
+        assert "Top:" in text
 
     def test_no_personal_data(self):
         """Email addresses must never appear in share text."""
@@ -231,6 +236,132 @@ class TestGenerateStatsShareText:
         )
         assert "1 sender" in text
         assert "senders" not in text
+
+
+# ── Example output tests ─────────────────────────────────────────────────────
+
+
+class TestShareExamples:
+    """
+    Concrete end-to-end examples that pin the exact shape of share text.
+
+    These serve as specification: if you change the output format, update
+    these tests first so the intent is explicit.
+    """
+
+    def _gen(self, **kw):
+        from mailtrim.core.sender_stats import generate_stats_share_text
+
+        defaults = dict(
+            reclaimable_mb_val=0.0,
+            sender_count=1,
+            email_count=10,
+            top_domains=[],
+            scan_seconds=0,
+            fmt="twitter",
+        )
+        return generate_stats_share_text(**{**defaults, **kw})
+
+    def test_example_big_cleanup_twitter(self):
+        """Classic result: many emails, significant MB, two known sources."""
+        text = self._gen(
+            reclaimable_mb_val=87.4,
+            sender_count=3,
+            email_count=495,
+            top_domains=["linkedin.com", "github.com"],
+            scan_seconds=4,
+            fmt="twitter",
+        )
+        # Core facts present
+        assert "495" in text
+        assert "87.4 MB" in text
+        assert "3 senders" in text
+        assert "4s" in text
+        # Human-readable source labels
+        assert "LinkedIn" in text
+        assert "GitHub" in text
+        # Privacy: no raw email addresses
+        assert "@" not in text
+        # Under preferred 200-char limit when sources fit
+        assert len(text) <= 200
+        # Has emoji and URL
+        assert "🧹" in text
+        assert "github.com/sadhgurutech/mailtrim" in text
+
+    def test_example_single_sender_twitter(self):
+        """Single-sender result uses singular 'sender', not 'senders'."""
+        text = self._gen(
+            reclaimable_mb_val=26.1,
+            sender_count=1,
+            email_count=183,
+            top_domains=["substack.com"],
+            scan_seconds=2,
+            fmt="twitter",
+        )
+        assert "183" in text
+        assert "26.1 MB" in text
+        assert "1 sender" in text
+        assert "senders" not in text
+        assert "Substack" in text
+        assert "2s" in text
+        assert len(text) <= 280
+
+    def test_example_no_mb_no_domains_twitter(self):
+        """When there's no reclaimable storage and no known domains, output stays clean."""
+        text = self._gen(
+            reclaimable_mb_val=0,
+            sender_count=5,
+            email_count=300,
+            top_domains=[],
+            scan_seconds=6,
+            fmt="twitter",
+        )
+        assert "300" in text
+        assert "5 senders" in text
+        assert "6s" in text
+        assert "MB" not in text
+        # No sources line when top_domains is empty
+        assert "Top:" not in text
+        assert len(text) <= 280
+
+    def test_example_plain_format(self):
+        """Plain format: no emoji, sources labeled, same facts."""
+        text = self._gen(
+            reclaimable_mb_val=15.0,
+            sender_count=2,
+            email_count=200,
+            top_domains=["medium.com", "notion.so"],
+            scan_seconds=3,
+            fmt="plain",
+        )
+        assert "🧹" not in text
+        assert "200" in text
+        assert "15.0 MB" in text
+        assert "2 senders" in text
+        assert "Medium" in text
+        assert "Notion" in text
+        assert "Top sources:" in text
+        assert "3s" in text
+        assert "github.com/sadhgurutech/mailtrim" in text
+
+    def test_example_sensitive_domain_filtered(self):
+        """Sensitive domains (bank, health …) are silently excluded from share text."""
+        text = self._gen(
+            reclaimable_mb_val=20.0,
+            sender_count=3,
+            email_count=150,
+            top_domains=["bankofamerica.com", "healthinsurance.com", "linkedin.com"],
+            scan_seconds=3,
+            fmt="twitter",
+        )
+        # Sensitive domains must not appear
+        assert "bankofamerica" not in text
+        assert "healthinsurance" not in text
+        # Safe domain is shown
+        assert "LinkedIn" in text
+        # Core numbers still present
+        assert "150" in text
+        assert "3 senders" in text
 
 
 # ── CLI integration tests ─────────────────────────────────────────────────────

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -5,33 +5,12 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+# ── DB isolation ──────────────────────────────────────────────────────────────
+
 
 @pytest.fixture(autouse=True)
-def isolated_db(monkeypatch, tmp_path):
-    """Point all storage to a temp dir so tests don't touch ~/.mailtrim."""
-    monkeypatch.setenv("MAILTRIM_DIR", str(tmp_path))
-    # Reset module-level singletons
-    import mailtrim.config as cfg
-
-    cfg._settings = None
-    cfg.DATA_DIR = tmp_path
-    cfg.DB_PATH = tmp_path / "test.db"
-    cfg.UNDO_LOG_DIR = tmp_path / "undo_logs"
-
-    import mailtrim.core.storage as storage
-
-    storage._engine = None
-    storage._SessionLocal = None
-
-    yield
-
-    # Cleanup
-    import mailtrim.core.storage as storage
-
-    if storage._engine:
-        storage._engine.dispose()
-    storage._engine = None
-    storage._SessionLocal = None
+def _use_clean_db(clean_db):
+    """Apply the shared in-memory DB fixture to every test in this module."""
 
 
 def test_email_record_upsert():


### PR DESCRIPTION
## Summary

- **`ai_status_line(mode)`** added to `mailtrim/core/ai/mode.py` — returns `(label, note, color)` for all three modes, used to print a consistent AI badge across commands
- **AI badge** printed in `stats`, `quickstart`, and `doctor` output: `AI: OFF (no data leaves your machine)` / `AI: LOCAL (runs on your machine)` / `AI: CLOUD (email data may be sent to Anthropic)`
- **`_cloud_ai_warning()` panel** shown before any cloud AI command (triage, bulk, avoid, digest) with a disable hint: `mailtrim config ai-mode off`
- **Hard blocking** — `require_cloud()` now wrapped in `try/except` in all four AI commands so `AIModeError` is caught by `_handle_error`, printed with full multi-line detail, and exits 1 cleanly
- **No fallback, no silent behavior** — every AI path is gated; off-mode blocks immediately with an actionable enable hint

## Enforcement points

| Call site | Mode required | Blocked when |
|---|---|---|
| `triage` | `cloud` | `off`, `local` |
| `bulk` | `cloud` | `off`, `local` |
| `avoid` | `cloud` | `off`, `local` |
| `digest` | `cloud` | `off`, `local` |
| `stats --ai` | `local` | `off` |
| `purge --ai` | `local` | `off` |

## Example CLI output

**Default (ai_mode=off):**
```
  AI: OFF  no data leaves your machine
```

**Cloud mode — triage/bulk/avoid/digest shows warning first:**
```
╭─────────────────────────────────────────────╮
│  ⚠  Cloud AI is enabled                     │
│  This command will send email subjects       │
│  and/or snippets to Anthropic's servers.    │
│  To disable:  mailtrim config ai-mode off   │
╰─────────────────────────────────────────────╯
```

**Off-mode block:**
```
AI blocked: AI is disabled (ai_mode=off).
  To use cloud AI:  mailtrim config ai-mode cloud
  Warning: cloud mode sends email subjects and snippets to Anthropic.
```

## Test plan

- [x] `TestAiStatusLine` — 9 tests covering label/note/color for all three modes
- [x] `TestHandleErrorAIModeError` — error format, exit code 1, enable hint shown
- [x] `TestStatsBadge` — badge present for off/local/cloud, correct label per mode
- [x] `TestQuickstartBadge` — same coverage for quickstart
- [x] `TestDoctorBadge` — badge present for off/cloud
- [x] `TestCloudWarning` — warning panel shown in triage/bulk/avoid/digest with cloud mode; Anthropic and disable hint visible
- [x] `TestOffModeBlocking` — all four cloud commands exit 1 in off mode; cloud warning NOT shown when blocked
- [x] 317 total tests passing, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)