### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/mailtrim/__init__.py
+++ b/mailtrim/__init__.py
@@ -1,3 +1,3 @@
 """mailtrim: Privacy-first, AI-powered Gmail inbox management."""
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mailtrim"
-version = "0.2.2"
+version = "0.3.0"
 description = "Privacy-first Gmail inbox management — local-first core, optional AI via Anthropic API"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for the v0.3.0 release.

Merge this, then tag `v0.3.0` on main to trigger the PyPI publish workflow.