### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.4.1] — 2026-05-03
+
+### Fixed
+- **Gmail setup now clears stale IMAP settings from `.env`** — switching from IMAP back to
+  Gmail via `mailtrim setup` previously left `MAILTRIM_IMAP_USER` and related keys in `.env`,
+  causing every subsequent command to prompt for an IMAP password even on a Gmail account.
+  Setup now writes `MAILTRIM_PROVIDER=gmail` and strips all `MAILTRIM_IMAP_*` lines on success.
+- **Consistent provider resolution** — `_resolve_imap_settings` had two bugs:
+  1. The "gmail" fallback only fired when settings failed to load entirely; if `MAILTRIM_PROVIDER`
+     was absent from `.env` (pre-v0.3.0 installs), the resolved provider silently became `""`.
+     Fixed to `provider or persisted or "gmail"` — "gmail" is always the ultimate default.
+  2. Stale IMAP settings (server, user, port, folder) were returned even when the resolved
+     provider was Gmail, allowing them to accidentally satisfy the IMAP password prompt guard.
+     IMAP values are now zeroed immediately when `resolved_provider != "imap"`.
+- **Silent `except OSError: pass` replaced with explicit warnings** — `.env` write failures in
+  both the Gmail and IMAP setup paths now print a yellow warning explaining what failed and how
+  to recover, rather than silently swallowing the error.
+
+### Added
+- **Provider indicator line** — `stats`, `quickstart`, and `purge` now print a single dim line
+  at the start of each run showing the active provider:
+  - Gmail: `Provider: Gmail`
+  - IMAP: `Provider: IMAP (server: imap.example.com)`
+
+---
+
 ## [0.4.0] — 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ mailtrim quickstart    # one command — scans, ranks, shows the safest first ac
 ### `mailtrim stats`
 
 ```
+Provider: Gmail
 ✨ Scan complete — analyzed 2,341 emails across 41 senders in 4s
   AI: OFF  no data leaves your machine
 
@@ -289,6 +290,7 @@ mailtrim doctor    # diagnoses auth, Gmail connection, storage, config
 | Scan feels slow | `mailtrim stats --max-scan 500` |
 | Not seeing enough senders | `mailtrim stats --scope anywhere` |
 | IMAP connection failed | Re-run `mailtrim setup` to update server/user settings |
+| Switched to Gmail but still prompted for IMAP password | Re-run `mailtrim setup` and choose Gmail — this clears stale IMAP settings from `.env` |
 | IMAP undo restores fewer emails than expected | Normal on non-Gmail IMAP — UIDs are folder-specific; check Trash manually for any remaining emails |
 | IMAP purge returns 0 emails moved | Server may lack a Trash folder; run `mailtrim doctor` to check |
 

--- a/mailtrim/__init__.py
+++ b/mailtrim/__init__.py
@@ -1,3 +1,3 @@
 """mailtrim: Privacy-first email inbox management — Gmail + IMAP."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mailtrim"
-version = "0.4.0"
+version = "0.4.1"
 description = "Privacy-first email inbox management — Gmail + IMAP, local-first core, optional AI via Anthropic API"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` and `__init__.py` to `0.4.1`
- Updates `CHANGELOG.md` with all 0.4.1 changes
- Updates `README.md` with provider indicator in example output and new troubleshooting row

## What's in 0.4.1
- Gmail setup clears stale IMAP settings from `.env` (#44)
- Consistent provider resolution — fixed fallback + Gmail isolation (#45)
- Silent `except OSError: pass` replaced with explicit warnings
- Provider indicator line in `stats`, `quickstart`, `purge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)