### PR TITLE
feat: add --version / -V flag and version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `mailtrim version` command and `mailtrim --version` / `-V` flag — prints `mailtrim <version>`
+  and exits; version string sourced from `mailtrim.__version__` (single source of truth)
+
 ---
 
 ## [0.4.1] — 2026-05-03

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ See [PRIVACY.md](PRIVACY.md) for the full data flow.
 | `mailtrim purge --sort size` | Show largest senders first |
 | `mailtrim undo` | List recent operations and reverse any of them |
 | `mailtrim undo 3` | Reverse operation #3 specifically |
+| `mailtrim version` | Show installed version (`--version` / `-V` also works) |
 | `mailtrim doctor` | Health check — auth, Gmail connection, storage, config |
 | `mailtrim sync` | Pull inbox into local cache for faster repeated queries |
 | `mailtrim unsubscribe email@sender.com` | Unsubscribe via List-Unsubscribe header |

--- a/mailtrim/cli/main.py
+++ b/mailtrim/cli/main.py
@@ -26,6 +26,26 @@ app = typer.Typer(
 console = Console()
 
 
+@app.callback(invoke_without_command=True)
+def _main(
+    ctx: typer.Context = typer.Option(None, hidden=True),
+    version: bool = typer.Option(
+        False, "--version", "-V", is_eager=True, help="Show version and exit."
+    ),
+) -> None:
+    if version:
+        typer.echo(f"mailtrim {__version__}")
+        raise typer.Exit()
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+
+
+@app.command()
+def version() -> None:
+    """Show the installed mailtrim version."""
+    typer.echo(f"mailtrim {__version__}")
+
+
 # ── Lazy imports to keep startup fast ────────────────────────────────────────
 
 
@@ -3521,12 +3541,6 @@ def privacy():
     console.print("  [green]✓[/green]  No account data shared with mailtrim project")
     console.print("  [green]✓[/green]  OAuth token stored locally at chmod 600")
     console.print()
-
-
-@app.command()
-def version():
-    """Print version."""
-    console.print(f"mailtrim {__version__}")
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,46 @@
+"""Tests for --version flag and version command."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from mailtrim import __version__
+from mailtrim.cli.main import app
+
+runner = CliRunner()
+
+
+def test_version_flag_exits_zero():
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+
+
+def test_version_flag_output():
+    result = runner.invoke(app, ["--version"])
+    assert result.output.strip() == f"mailtrim {__version__}"
+
+
+def test_version_flag_short_form():
+    result = runner.invoke(app, ["-V"])
+    assert result.output.strip() == f"mailtrim {__version__}"
+
+
+def test_version_command_exits_zero():
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+
+
+def test_version_command_output():
+    result = runner.invoke(app, ["version"])
+    assert result.output.strip() == f"mailtrim {__version__}"
+
+
+def test_version_contains_package_version():
+    result = runner.invoke(app, ["--version"])
+    assert __version__ in result.output
+
+
+def test_version_flag_and_command_match():
+    flag_out = runner.invoke(app, ["--version"]).output.strip()
+    cmd_out = runner.invoke(app, ["version"]).output.strip()
+    assert flag_out == cmd_out


### PR DESCRIPTION
## Summary
- `mailtrim --version` and `mailtrim -V` print `mailtrim 0.4.1` and exit immediately
- `mailtrim version` command does the same
- Single source of truth: `mailtrim.__version__` — no duplicated string
- Removed a pre-existing `version` command that used Rich formatting (inconsistent with the plain output contract)

## Implementation
Typer `@app.callback(invoke_without_command=True)` with `is_eager=True` on the `--version` option — fires before any subcommand logic runs, including the help display.

## Test plan
- [x] 7 tests: flag exits 0, flag output, `-V` short form, command exits 0, command output, version in output, flag and command match
- [x] 393 tests total pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)