### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [0.4.2] — 2026-05-03
+
 ### Added
 - `mailtrim version` command and `mailtrim --version` / `-V` flag — prints `mailtrim <version>`
   and exits; version string sourced from `mailtrim.__version__` (single source of truth)

--- a/mailtrim/__init__.py
+++ b/mailtrim/__init__.py
@@ -1,3 +1,3 @@
 """mailtrim: Privacy-first email inbox management — Gmail + IMAP."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mailtrim"
-version = "0.4.1"
+version = "0.4.2"
 description = "Privacy-first email inbox management — Gmail + IMAP, local-first core, optional AI via Anthropic API"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps to 0.4.2 for PyPI release.

What's new in 0.4.2:
- `mailtrim --version` / `-V` flag and `mailtrim version` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)